### PR TITLE
Time zone handling: convert DateTime to UTC, NaiveDateTime to floating reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ chrono = "0.4"
 [dependencies.uuid]
 features = ["v4"]
 version = "0.5"
+
+[dev-dependencies]
+pretty_assertions = "0.6"

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -4,14 +4,13 @@ use chrono::*;
 fn main(){
 
     let todo = Todo::new()
-        .starts(Local::now())
-        .ends(Local::now())
+        .starts(Local::now().naive_local())
+        .ends(Local::now().naive_local())
         .priority(12)
         .percent_complete(28)
         .status(TodoStatus::Completed)
-        .completed(&Local::now())
-        .due(&Local::now())
-        .due(&Local::now())
+        .completed(Utc::now())
+        .due(Local::now().with_timezone(&Utc))
         .done();
 
     println!("{}", todo.to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,18 @@
 //! calendar.add(bday);
 //! # }
 //! ```
+//!
+//! ## Breaking API Changes in version 0.7.0
+//!
+//! - [Todo::due] and [Todo::completed] now take their date-time argument by value rather than by
+//!   reference
+//! - [Todo::completed] now requires its [chrono::DateTime] argument to have exactly [chrono::Utc]
+//!   specified as its time zone as mandated by the RFC.
+//! - [Component::starts], [Component::ends] and [Todo::due] now take newly introduced
+//!   [CalendarDateTime] (through `Into<CalendarDateTime>` indirection). This allows callers to
+//!   define time zone handling. Conversions from [`chrono::NaiveDateTime`] and
+//!   [`chrono::DateTime<Utc>`](chrono::DateTime) are provided for ergonomics, the latter also restoring API
+//!   compatibility in case of UTC date-times.
 
 #![warn(missing_docs,
         missing_copy_implementations,
@@ -83,7 +95,7 @@ mod calendar;
 //pub mod repeats;
 pub use crate::properties::{Property, Parameter, Class, ValueType};
 pub use crate::properties::{TodoStatus, EventStatus};
-pub use crate::components::{Event, Todo, Component};
+pub use crate::components::{CalendarDateTime, Event, Todo, Component};
 pub use crate::calendar::Calendar;
 
 // TODO Calendar TimeZone VTIMEZONE STANDARD DAYLIGHT (see thunderbird exports)

--- a/tests/calendar.rs
+++ b/tests/calendar.rs
@@ -10,9 +10,9 @@ CALSCALE:GREGORIAN\r
 BEGIN:VEVENT\r
 CLASS:CONFIDENTIAL\r
 DESCRIPTION:Description\r
-DTEND:20140709T091011\r
+DTEND:20140709T091011Z\r
 DTSTAMP:20190307T181159\r
-DTSTART:20140708T091011\r
+DTSTART:20140708T071011Z\r
 LOCATION:Somewhere\r
 PRIORITY:10\r
 STATUS:TENTATIVE\r
@@ -20,7 +20,7 @@ SUMMARY:summary\r
 UID:euid\r
 END:VEVENT\r
 BEGIN:VTODO\r
-COMPLETED:20140709T091011\r
+COMPLETED:20140709T091011Z\r
 DTSTAMP:20190307T181159\r
 DUE:20140708T091011\r
 PERCENT-COMPLETE:95\r
@@ -39,7 +39,7 @@ fn test_calendar_to_string() {
     let utc_date = Utc.ymd(2014, 7, 9).and_hms(9, 10, 11);
     let event = Event::new()
         .status(EventStatus::Tentative)
-        .starts(cest_date)
+        .starts(cest_date.with_timezone(&Utc))
         .ends(utc_date)
         .priority(11) // converted to 10
         .summary("summary")
@@ -52,8 +52,8 @@ fn test_calendar_to_string() {
     calendar.push(event);
     let todo = Todo::new()
         .percent_complete(95)
-        .due(&cest_date)
-        .completed(&utc_date)
+        .due(cest_date.naive_local())
+        .completed(utc_date)
         .summary("A Todo")
         .uid("todouid")
         .add_property("DTSTAMP", "20190307T181159")

--- a/tests/calendar.rs
+++ b/tests/calendar.rs
@@ -1,5 +1,5 @@
 use chrono::prelude::*;
-use icalendar::{Calendar, Class, Component, Event, EventStatus};
+use icalendar::{Calendar, Class, Component, Event, EventStatus, Todo};
 
 const EXPECTED_CAL_CONTENT: &str = "\
 BEGIN:VCALENDAR\r
@@ -18,16 +18,28 @@ STATUS:TENTATIVE\r
 SUMMARY:summary\r
 UID:euid\r
 END:VEVENT\r
+BEGIN:VTODO\r
+COMPLETED:20140709T091011\r
+DTSTAMP:20190307T181159\r
+DUE:20140708T091011\r
+PERCENT-COMPLETE:95\r
+SUMMARY:A Todo\r
+UID:todouid\r
+END:VTODO\r
 END:VCALENDAR\r
 ";
 
 #[test]
 fn test_calendar_to_string() {
     let mut calendar = Calendar::new();
+    let cest_date = FixedOffset::east(2 * 3600)
+        .ymd(2014, 7, 8)
+        .and_hms(9, 10, 11);
+    let utc_date = Utc.ymd(2014, 7, 9).and_hms(9, 10, 11);
     let event = Event::new()
         .status(EventStatus::Tentative)
-        .starts(Local.ymd(2014, 7, 8).and_hms(9, 10, 11))
-        .ends(Local.ymd(2014, 7, 9).and_hms(9, 10, 11))
+        .starts(cest_date)
+        .ends(utc_date)
         .priority(11) // converted to 10
         .summary("summary")
         .description("Description")
@@ -37,5 +49,14 @@ fn test_calendar_to_string() {
         .add_property("DTSTAMP", "20190307T181159")
         .done();
     calendar.push(event);
+    let todo = Todo::new()
+        .percent_complete(95)
+        .due(&cest_date)
+        .completed(&utc_date)
+        .summary("A Todo")
+        .uid("todouid")
+        .add_property("DTSTAMP", "20190307T181159")
+        .done();
+    calendar.push(todo);
     assert_eq!(calendar.to_string(), EXPECTED_CAL_CONTENT);
 }

--- a/tests/calendar.rs
+++ b/tests/calendar.rs
@@ -1,5 +1,6 @@
 use chrono::prelude::*;
 use icalendar::{Calendar, Class, Component, Event, EventStatus, Todo};
+use pretty_assertions::assert_eq;
 
 const EXPECTED_CAL_CONTENT: &str = "\
 BEGIN:VCALENDAR\r


### PR DESCRIPTION
This introduces proper time zone and "floating" date-time handling for
Component::start() and Component::end(), by following means:

- we introduce new thin enum wrapper CalendarDateTime, which is either floating
  (as per RFC) or in UTC (extendable in future for timezone-referenced date-time).
- we make Component::start(), Component::end() accept our CalendarDateTime instead
  of `chrono::DateTime<TZ>` (more precisely we accept `T: Into<CalendarDateTime>`).
- we implement `From<chrono:DateTime<TZ>>` for CalendarDateTime, restoring source
  compatibility with previous versions (but not interpretation compatibility),
  and providing caller convenience. The implementation converts passed
  date-time to Utc.
- we also implement `From<chrono:NaiveDateTime>` for CalendarDateTime, which
  converts to floating date-time per the RFC. This allows users to opt-in for
  this special behaviour.

As demonstrated by the test, this is a change of behaviour of existing user
code (and should be probably mentioned in docs or a kind of changelog):

If user pased date-time "2014-07-08 09:10:11 CEST (+02:00)", the library would
previously emit "20140708T091011" (floating), now it emits "20140708T071011Z"
(Utc).
I argue that the current behaviour is more or less incorrect, as chrono
DateTime<TZ> conveys mandatory time-zone information, which currently gets
discarded.

This change allows users to explicicly opt-in to the "flating" behaviour by
passing NaiveDateTime. This shuold however not be frequent, even the RFC
mentions:

> In most cases, a fixed time is desired.

Note that some some eligible date-time fields are not changed by this commit:
Todo::due() and Todo::completed().

Fixes #2.