### PR TITLE
feat: add TryInto<String> for &Calendar

### DIFF
--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -105,6 +105,15 @@ impl ToString for Calendar {
     }
 }
 
+impl std::convert::TryInto<String> for &Calendar {
+    type Error = std::fmt::Error;
+    fn try_into(self) -> Result<String, Self::Error> {
+        let mut out_string = String::new();
+        self.fmt_write(&mut out_string)?;
+        Ok(out_string)
+    }
+}
+
 impl Deref for Calendar {
     type Target = [CalendarElement];
 

--- a/tests/try_into_string.rs
+++ b/tests/try_into_string.rs
@@ -1,0 +1,27 @@
+use chrono::*;
+use icalendar::*;
+use std::convert::TryInto;
+
+#[test]
+fn try_into_string() -> Result<(), Box<dyn std::error::Error>> {
+    let bday = Event::new()
+        .start_date(Utc.ymd(2016, 3, 15))
+        .end_date(Utc.ymd(2016, 3, 15))
+        .summary("My Birthday")
+        .description(
+            r#"Hey, I'm gonna have a party
+BYOB: Bring your own beer.
+Hendrik"#,
+        )
+        .done();
+
+    let mut calendar = Calendar::new();
+    calendar.push(bday);
+
+    let s1: String = (&calendar).try_into()?;
+    let s2: String = calendar.to_string();
+
+    println!("{:?}", (s1, s2));
+
+    Ok(())
+}


### PR DESCRIPTION
adding `TryInto<String>` for `&Calendar`, so it's not consuming
as mentioned in #11 