### PR TITLE
fix: remove ToString and implement fmt::Display instead

### DIFF
--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -87,11 +87,8 @@ impl Calendar {
     }
 
     /// Prints to stdout
-    /// FIXME code repetition
     pub fn print(&self) -> Result<(), fmt::Error> {
-        let mut out = String::new();
-        self.fmt_write(&mut out)?;
-        print_crlf!("{}", out);
+        print_crlf!("{}", self);
         Ok(())
     }
 }

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -96,12 +96,9 @@ impl Calendar {
     }
 }
 
-impl ToString for Calendar {
-    /// # panics
-    fn to_string(&self) -> String {
-        let mut out_string = String::new();
-        self.fmt_write(&mut out_string).unwrap();
-        out_string
+impl fmt::Display for Calendar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_write(f)
     }
 }
 


### PR DESCRIPTION
As pointed out already in #11 (ref [std::string::ToString](https://doc.rust-lang.org/stable/std/string/trait.ToString.html)) implementing `ToString` directly isn't such a great idea, especially since it may panic. Hence this replaces our `ToString` impl with a `Display` impl.