### PR TITLE
Add getters for calendar and event properties

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -12,6 +12,7 @@ mod todo;
 mod venue;
 
 pub use date_time::CalendarDateTime;
+use date_time::NAIVE_DATE_FORMAT;
 pub use event::*;
 pub use other::*;
 pub use todo::*;
@@ -153,9 +154,12 @@ pub trait Component {
     {
         // DTSTART
         self.append_property(
-            Property::new("DTSTART", date.format("%Y%m%d").to_string().as_ref())
-                .append_parameter(ValueType::Date)
-                .done(),
+            Property::new(
+                "DTSTART",
+                date.format(NAIVE_DATE_FORMAT).to_string().as_ref(),
+            )
+            .append_parameter(ValueType::Date)
+            .done(),
         );
         self
     }
@@ -167,7 +171,7 @@ pub trait Component {
     {
         // DTSTART
         self.append_property(
-            Property::new("DTEND", date.format("%Y%m%d").to_string().as_ref())
+            Property::new("DTEND", date.format(NAIVE_DATE_FORMAT).to_string().as_ref())
                 .append_parameter(ValueType::Date)
                 .done(),
         );
@@ -183,12 +187,15 @@ pub trait Component {
     {
         // DTSTART
         self.append_property(
-            Property::new("DTSTART", date.format("%Y%m%d").to_string().as_ref())
-                .append_parameter(ValueType::Date)
-                .done(),
+            Property::new(
+                "DTSTART",
+                date.format(NAIVE_DATE_FORMAT).to_string().as_ref(),
+            )
+            .append_parameter(ValueType::Date)
+            .done(),
         )
         .append_property(
-            Property::new("DTEND", date.format("%Y%m%d").to_string().as_ref())
+            Property::new("DTEND", date.format(NAIVE_DATE_FORMAT).to_string().as_ref())
                 .append_parameter(ValueType::Date)
                 .done(),
         );

--- a/src/components.rs
+++ b/src/components.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use std::{collections::BTreeMap, fmt, mem};
 
 use crate::properties::*;
-use date_time::NAIVE_DATE_FORMAT;
+use date_time::naive_date_to_property;
 
 mod date_time;
 mod event;
@@ -168,14 +168,7 @@ pub trait Component {
         TZ::Offset: fmt::Display,
     {
         // DTSTART
-        self.append_property(
-            Property::new(
-                "DTSTART",
-                date.format(NAIVE_DATE_FORMAT).to_string().as_ref(),
-            )
-            .append_parameter(ValueType::Date)
-            .done(),
-        );
+        self.append_property(naive_date_to_property(date.naive_local(), "DTSTART"));
         self
     }
 
@@ -184,12 +177,7 @@ pub trait Component {
     where
         TZ::Offset: fmt::Display,
     {
-        // DTSTART
-        self.append_property(
-            Property::new("DTEND", date.format(NAIVE_DATE_FORMAT).to_string().as_ref())
-                .append_parameter(ValueType::Date)
-                .done(),
-        );
+        self.append_property(naive_date_to_property(date.naive_local(), "DTEND"));
         self
     }
 
@@ -200,20 +188,8 @@ pub trait Component {
     where
         TZ::Offset: fmt::Display,
     {
-        // DTSTART
-        self.append_property(
-            Property::new(
-                "DTSTART",
-                date.format(NAIVE_DATE_FORMAT).to_string().as_ref(),
-            )
-            .append_parameter(ValueType::Date)
-            .done(),
-        )
-        .append_property(
-            Property::new("DTEND", date.format(NAIVE_DATE_FORMAT).to_string().as_ref())
-                .append_parameter(ValueType::Date)
-                .done(),
-        );
+        self.append_property(naive_date_to_property(date.naive_local(), "DTSTART"))
+            .append_property(naive_date_to_property(date.naive_local(), "DTEND"));
         self
     }
 

--- a/src/components/date_time.rs
+++ b/src/components/date_time.rs
@@ -84,6 +84,15 @@ impl DatePerhapsTime {
             Some(CalendarDateTime::from_str(property.value())?.into())
         }
     }
+
+    pub(crate) fn to_property(&self, key: &str) -> Property {
+        match self {
+            Self::DateTime(date_time) => Property::new(key, &date_time.to_string()),
+            Self::Date(date) => Property::new(key, &date.format(NAIVE_DATE_FORMAT).to_string())
+                .append_parameter(ValueType::Date)
+                .done(),
+        }
+    }
 }
 
 impl From<CalendarDateTime> for DatePerhapsTime {

--- a/src/components/date_time.rs
+++ b/src/components/date_time.rs
@@ -1,6 +1,10 @@
 use chrono::*;
 use std::fmt;
 
+const NAIVE_DATE_TIME_FORMAT: &str = "%Y%m%dT%H%M%S";
+const UTC_DATE_TIME_FORMAT: &str = "%Y%m%dT%H%M%SZ";
+pub(crate) const NAIVE_DATE_FORMAT: &str = "%Y%m%d";
+
 /// Representation of various forms of `DATE-TIME` per
 /// [RFC 5545, Section 3.3.5](https://tools.ietf.org/html/rfc5545#section-3.3.5)
 ///
@@ -27,8 +31,8 @@ impl fmt::Display for CalendarDateTime {
     /// Format date-time in RFC 5545 compliant manner.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            CalendarDateTime::Floating(naive_dt) => naive_dt.format("%Y%m%dT%H%M%S").fmt(f),
-            CalendarDateTime::Utc(utc_dt) => utc_dt.format("%Y%m%dT%H%M%SZ").fmt(f),
+            CalendarDateTime::Floating(naive_dt) => naive_dt.format(NAIVE_DATE_TIME_FORMAT).fmt(f),
+            CalendarDateTime::Utc(utc_dt) => utc_dt.format(UTC_DATE_TIME_FORMAT).fmt(f),
         }
     }
 }

--- a/src/components/date_time.rs
+++ b/src/components/date_time.rs
@@ -43,10 +43,8 @@ impl CalendarDateTime {
     pub(crate) fn from_str(s: &str) -> Option<Self> {
         if let Ok(naive_date_time) = NaiveDateTime::parse_from_str(s, NAIVE_DATE_TIME_FORMAT) {
             Some(naive_date_time.into())
-        } else if let Some(utc) = parse_utc_date_time(s) {
-            Some(utc.into())
         } else {
-            None
+            parse_utc_date_time(s).map(Into::into)
         }
     }
 }
@@ -95,10 +93,10 @@ impl DatePerhapsTime {
         }
     }
 
-    pub(crate) fn to_property(&self, key: &str) -> Property {
+    pub(crate) fn to_property(self, key: &str) -> Property {
         match self {
             Self::DateTime(date_time) => Property::new(key, &date_time.to_string()),
-            Self::Date(date) => naive_date_to_property(*date, key),
+            Self::Date(date) => naive_date_to_property(date, key),
         }
     }
 }

--- a/src/components/event.rs
+++ b/src/components/event.rs
@@ -19,10 +19,15 @@ impl Event {
         }
     }
 
-    ///  Defines the overall status or confirmation
+    /// Defines the overall status or confirmation
     pub fn status(&mut self, status: EventStatus) -> &mut Self {
         self.append_property(status.into());
         self
+    }
+
+    /// Gets the overall status or confirmation.
+    pub fn get_status(&self) -> Option<EventStatus> {
+        EventStatus::from_str(self.property_value("STATUS")?)
     }
 
     //pub fn repeats<R:Repeater+?Sized>(&mut self, repeat: R) -> &mut Self {
@@ -30,4 +35,19 @@ impl Event {
     //}
 }
 
-// impl std::Str
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_properties_unset() {
+        let event = Event::new();
+        assert_eq!(event.get_status(), None);
+    }
+
+    #[test]
+    fn get_properties_set() {
+        let event = Event::new().status(EventStatus::Tentative).done();
+        assert_eq!(event.get_status(), Some(EventStatus::Tentative));
+    }
+}

--- a/src/components/todo.rs
+++ b/src/components/todo.rs
@@ -1,6 +1,6 @@
 use chrono::*;
 
-use super::date_time::UTC_DATE_TIME_FORMAT;
+use super::date_time::parse_utc_date_time;
 use super::*;
 
 /// VTODO  [(RFC 5545, Section 3.6.2 )](https://tools.ietf.org/html/rfc5545#section-3.6.2)
@@ -67,7 +67,7 @@ impl Todo {
     /// must be a date-time in UTC format.
     pub fn get_completed(&self) -> Option<DateTime<Utc>> {
         let completed = self.property_value("COMPLETED")?;
-        Utc.datetime_from_str(completed, UTC_DATE_TIME_FORMAT).ok()
+        parse_utc_date_time(completed)
     }
 
     /// Defines the overall status or confirmation

--- a/src/components/todo.rs
+++ b/src/components/todo.rs
@@ -41,9 +41,9 @@ impl Todo {
     /// Set the [`DUE`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.3) property
     ///
     /// See [`CalendarDateTime`] for info how are different [`chrono`] types converted automatically.
-    pub fn due<T: Into<CalendarDateTime>>(&mut self, dt: T) -> &mut Self {
-        let calendar_dt: CalendarDateTime = dt.into();
-        self.add_property("DUE", &calendar_dt.to_string());
+    pub fn due<T: Into<DatePerhapsTime>>(&mut self, dt: T) -> &mut Self {
+        let calendar_dt: DatePerhapsTime = dt.into();
+        self.append_property(calendar_dt.to_property("DUE"));
         self
     }
 
@@ -128,5 +128,12 @@ mod tests {
             .done();
         assert_eq!(todo.get_due(), Some(utc_date_time.into()));
         assert_eq!(todo.get_completed(), Some(utc_date_time));
+    }
+
+    #[test]
+    fn get_dates_naive() {
+        let naive_date = NaiveDate::from_ymd(2001, 3, 13);
+        let todo = Todo::new().due(naive_date).done();
+        assert_eq!(todo.get_due(), Some(naive_date.into()));
     }
 }

--- a/src/components/todo.rs
+++ b/src/components/todo.rs
@@ -30,6 +30,13 @@ impl Todo {
         self
     }
 
+    /// Gets the [`PERCENT-COMPLETE`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.1.8) property.
+    ///
+    /// Ranges between 0 - 100.
+    pub fn get_percent_complete(&self) -> Option<u8> {
+        self.property_value("PERCENT-COMPLETE")?.parse().ok()
+    }
+
     /// Set the [`DUE`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.3) property
     ///
     /// See [`CalendarDateTime`] for info how are different [`chrono`] types converted automatically.
@@ -48,14 +55,40 @@ impl Todo {
         self
     }
 
-    ///  Defines the overall status or confirmation
-    ///
+    /// Defines the overall status or confirmation
     pub fn status(&mut self, status: TodoStatus) -> &mut Self {
         self.append_property(status.into());
         self
     }
 
+    /// Gets the overall status.
+    pub fn get_status(&self) -> Option<TodoStatus> {
+        TodoStatus::from_str(self.property_value("STATUS")?)
+    }
+
     //pub fn repeats<R:Repeater+?Sized>(&mut self, repeat: R) -> &mut Self {
     //    unimplemented!()
     //}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_properties_unset() {
+        let todo = Todo::new();
+        assert_eq!(todo.get_percent_complete(), None);
+        assert_eq!(todo.get_status(), None);
+    }
+
+    #[test]
+    fn get_properties_set() {
+        let todo = Todo::new()
+            .percent_complete(42)
+            .status(TodoStatus::NeedsAction)
+            .done();
+        assert_eq!(todo.get_percent_complete(), Some(42));
+        assert_eq!(todo.get_status(), Some(TodoStatus::NeedsAction));
+    }
 }

--- a/src/components/venue.rs
+++ b/src/components/venue.rs
@@ -27,6 +27,11 @@ impl Venue {
         self.add_property("STREET-ADDRESS", address)
     }
 
+    /// Gets the value of the STREET-ADDRESS `Property`.
+    pub fn get_street_address(&self) -> Option<&str> {
+        self.property_value("STREET-ADDRESS")
+    }
+
     /// Set the EXTENDED-ADDRESS `Property`
     ///
     /// This property provides the opportunity to include extended address information for a
@@ -37,11 +42,21 @@ impl Venue {
         self.add_property("EXTENDED-ADDRESS", address)
     }
 
+    /// Gets the value of the EXTENDED-ADDRESS `Property`.
+    pub fn get_extended_address(&self) -> Option<&str> {
+        self.property_value("EXTENDED-ADDRESS")
+    }
+
     /// Set the LOCALITY `Property`
     ///
     /// This specifies the city or locality of a venue.
     pub fn locality(&mut self, locality: &str) -> &mut Self {
         self.add_property("LOCALITY", locality)
+    }
+
+    /// Gets the value of the LOCALITY `Property`.
+    pub fn get_locality(&self) -> Option<&str> {
+        self.property_value("LOCALITY")
     }
 
     /// Set the REGION `Property`
@@ -51,6 +66,11 @@ impl Venue {
         self.add_property("REGION", region)
     }
 
+    /// Gets the value of the REGION `Property`.
+    pub fn get_region(&self) -> Option<&str> {
+        self.property_value("REGION")
+    }
+
     /// Set the COUNTRY `Property`
     ///
     /// This specifies the country of a location.
@@ -58,10 +78,54 @@ impl Venue {
         self.add_property("COUNTRY", country)
     }
 
+    /// Gets the value of the COUNTRY `Property`.
+    pub fn get_country(&self) -> Option<&str> {
+        self.property_value("COUNTRY")
+    }
+
     /// Set the POSTAL-CODE `Property`
     ///
     /// This specifies the postal code of a location.
     pub fn postal_code(&mut self, postal_code: &str) -> &mut Self {
         self.add_property("POSTAL-CODE", postal_code)
+    }
+
+    /// Gets the value of the POSTAL-CODE `Property`.
+    pub fn get_postal_code(&self) -> Option<&str> {
+        self.property_value("POSTAL-CODE")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_properties_unset() {
+        let venue = Venue::new();
+        assert_eq!(venue.get_street_address(), None);
+        assert_eq!(venue.get_extended_address(), None);
+        assert_eq!(venue.get_locality(), None);
+        assert_eq!(venue.get_region(), None);
+        assert_eq!(venue.get_country(), None);
+        assert_eq!(venue.get_postal_code(), None);
+    }
+
+    #[test]
+    fn get_properties_set() {
+        let venue = Venue::new()
+            .street_address("street address")
+            .extended_address("extended address")
+            .locality("locality")
+            .region("region")
+            .country("country")
+            .postal_code("postal code")
+            .done();
+        assert_eq!(venue.get_street_address(), Some("street address"));
+        assert_eq!(venue.get_extended_address(), Some("extended address"));
+        assert_eq!(venue.get_locality(), Some("locality"));
+        assert_eq!(venue.get_region(), Some("region"));
+        assert_eq!(venue.get_country(), Some("country"));
+        assert_eq!(venue.get_postal_code(), Some("postal code"));
     }
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -200,6 +200,17 @@ pub enum EventStatus {
     //Custom(&str)
 }
 
+impl EventStatus {
+    pub(crate) fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "TENTATIVE" => Some(Self::Tentative),
+            "CONFIRMED" => Some(Self::Confirmed),
+            "CANCELLED" => Some(Self::Cancelled),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 /// Encodes the status of a `Todo`
 /// <https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.1.11>
@@ -213,6 +224,18 @@ pub enum TodoStatus {
     /// Indicates to-do was cancelled.
     Cancelled,
     //Custom(&str)
+}
+
+impl TodoStatus {
+    pub(crate) fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "NEEDS-ACTION" => Some(Self::NeedsAction),
+            "COMPLETED" => Some(Self::Completed),
+            "IN-PROCESS" => Some(Self::InProcess),
+            "CANCELLED" => Some(Self::Cancelled),
+            _ => None,
+        }
+    }
 }
 
 //pub enum JournalStatuw{

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -42,14 +42,19 @@ impl Property {
         }
     }
 
-    /// Clones the key field.
+    /// Returns a reference to the key field.
     pub fn key(&self) -> &str {
         &self.key
     }
 
-    /// Clones the key field.
+    /// Returns a reference to the key field.
     pub fn value(&self) -> &str {
         &self.val
+    }
+
+    /// Returns a reference to the parameters.
+    pub fn params(&self) -> &EntryParameters {
+        &self.params
     }
 
     /// Appends a new parameter.

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -57,6 +57,11 @@ impl Property {
         &self.params
     }
 
+    /// Returns the `VALUE` parameter, if any is specified.
+    pub fn value_type(&self) -> Option<ValueType> {
+        ValueType::from_str(&self.params.get("VALUE")?.val)
+    }
+
     /// Appends a new parameter.
     pub fn append_parameter<I: Into<Parameter>>(&mut self, into_parameter: I) -> &mut Self {
         let parameter = into_parameter.into();
@@ -166,6 +171,28 @@ pub enum ValueType {
     Uri,
     /// [`UtcOffset`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.14)
     UtcOffset,
+}
+
+impl ValueType {
+    pub(crate) fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "BINARY" => Some(Self::Binary),
+            "BOOLEAN" => Some(Self::Boolean),
+            "CAL-ADDRESS" => Some(Self::CalAddress),
+            "DATE" => Some(Self::Date),
+            "DATE-TIME" => Some(Self::DateTime),
+            "DURATION" => Some(Self::Duration),
+            "FLOAT" => Some(Self::Float),
+            "INTEGER" => Some(Self::Integer),
+            "PERIOD" => Some(Self::Period),
+            "RECUR" => Some(Self::Recur),
+            "TEXT" => Some(Self::Text),
+            "TIME" => Some(Self::Time),
+            "URI" => Some(Self::Uri),
+            "UTC-OFFSET" => Some(Self::UtcOffset),
+            _ => None,
+        }
+    }
 }
 
 impl From<ValueType> for Parameter {

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -105,6 +105,17 @@ pub enum Class {
     Confidential,
 }
 
+impl Class {
+    pub(crate) fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "PUBLIC" => Some(Self::Public),
+            "PRIVATE" => Some(Self::Private),
+            "CONFIDENTIAL" => Some(Self::Confidential),
+            _ => None,
+        }
+    }
+}
+
 impl From<Class> for Property {
     fn from(val: Class) -> Self {
         Property {


### PR DESCRIPTION
Being able to parse an iCalendar file into a `Calendar` isn't much use if you can't then access the data in it in a useful way.

This PR adds typed getters to `Calendar`, `Event`, `Todo`, `Venue` and the `Component` trait, to get the same properties as the builder methods allow to be set.

I also:

 * Derived some more basic traits (`Clone`, `PartialEq`, `Eq`) on some of the types that were missing them (`Parameter`, `Property`, `Class`, `ValueType`, `EventStatus`, `TodoStatus`).
 * Added a getter on `Property` for the `ValueType`, and for the map of parameters.
 * Allow a due date (without a time) to be specified for a `TODO`, as allowed by the RFC.