### PR TITLE
Fix typo in readme and missing export

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ There is a feature called `"parser"` which allows you to read calendars again li
 ```rust
 //... continue from previous example
 
-let parsed_capendar = my_calendar.parse::<Calendar>()?;
+let parsed_calendar = my_calendar.parse::<Calendar>()?;
 ```
 
 ## License

--- a/src/components/date_time.rs
+++ b/src/components/date_time.rs
@@ -76,7 +76,9 @@ impl From<NaiveDateTime> for CalendarDateTime {
 /// Either a `DATE-TIME` or a `DATE`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DatePerhapsTime {
+    /// A `DATE-TIME` property.
     DateTime(CalendarDateTime),
+    /// A `DATE` property.
     Date(NaiveDate),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ mod properties;
 
 pub use crate::{
     calendar::{Calendar, CalendarComponent},
-    components::{CalendarDateTime, Component, Event, Todo, Venue},
+    components::{CalendarDateTime, Component, DatePerhapsTime, Event, Todo, Venue},
     properties::{Class, EventStatus, Parameter, Property, TodoStatus, ValueType},
 };
 


### PR DESCRIPTION
#37 added the new type `DatePerhapsTime`, but I forgot to make a public export of it, so the new methods returning it couldn't actually be used. This PR fixes that, and also fixes a typo in the readme.