### PR TITLE
Clean up date/time handling and add support for date-times with a TZID

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ let my_calendar = Calendar::new()
     .push(
         // add an all-day event
         Event::new()
-            .all_day(Utc.ymd(2016, 3, 15))
+            .all_day(NaiveDate::from_ymd(2016, 3, 15))
             .summary("My Birthday")
             .description("Hey, I'm gonna have a party\nBYOB: Bring your own beer.\nHendrik")
             .done(),

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -31,7 +31,7 @@ fn main() {
         .push(
             // add an all-day event
             Event::new()
-                .all_day(Utc.ymd(2016, 3, 15))
+                .all_day(NaiveDate::from_ymd(2016, 3, 15))
                 .summary("My Birthday")
                 .description("Hey, I'm gonna have a party\nBYOB: Bring your own beer.\nHendrik")
                 .done(),

--- a/src/components.rs
+++ b/src/components.rs
@@ -142,18 +142,18 @@ pub trait Component {
 
     /// Set the [`DTSTART`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.4) [`Property`]
     ///
-    /// See [`CalendarDateTime`] for info how are different [`chrono`] types converted automatically.
-    fn starts<T: Into<CalendarDateTime>>(&mut self, dt: T) -> &mut Self {
+    /// See [`DatePerhapsTime`] for info how are different [`chrono`] types converted automatically.
+    fn starts<T: Into<DatePerhapsTime>>(&mut self, dt: T) -> &mut Self {
         let calendar_dt = dt.into();
-        self.add_property("DTSTART", &calendar_dt.to_string())
+        self.append_property(calendar_dt.to_property("DTSTART"))
     }
 
     /// Set the [`DTEND`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.2) [`Property`]
     ///
-    /// See [`CalendarDateTime`] for info how are different [`chrono`] types converted automatically.
-    fn ends<T: Into<CalendarDateTime>>(&mut self, dt: T) -> &mut Self {
+    /// See [`DatePerhapsTime`] for info how are different [`chrono`] types converted automatically.
+    fn ends<T: Into<DatePerhapsTime>>(&mut self, dt: T) -> &mut Self {
         let calendar_dt = dt.into();
-        self.add_property("DTEND", &calendar_dt.to_string())
+        self.append_property(calendar_dt.to_property("DTEND"))
     }
 
     /// Set the [`DTSTART`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.4) [`Property`], date only
@@ -402,10 +402,7 @@ mod tests {
     #[test]
     fn get_dates_naive() {
         let naive_date = NaiveDate::from_ymd(2001, 3, 13);
-        let event = Event::new()
-            .start_date(Utc.from_utc_date(&naive_date))
-            .end_date(Utc.from_utc_date(&naive_date))
-            .done();
+        let event = Event::new().starts(naive_date).ends(naive_date).done();
         assert_eq!(event.get_start(), Some(naive_date.into()));
         assert_eq!(event.get_end(), Some(naive_date.into()));
     }

--- a/src/components.rs
+++ b/src/components.rs
@@ -380,6 +380,21 @@ mod tests {
     }
 
     #[test]
+    fn get_date_times_tzid() {
+        let date_time = NaiveDate::from_ymd(2001, 3, 13).and_hms(14, 15, 16);
+        let date_time_tzid = CalendarDateTime::WithTimezone {
+            date_time,
+            tzid: "Pacific/Auckland".to_string(),
+        };
+        let event = Event::new()
+            .starts(date_time_tzid.clone())
+            .ends(date_time_tzid.clone())
+            .done();
+        assert_eq!(event.get_start(), Some(date_time_tzid.clone().into()));
+        assert_eq!(event.get_end(), Some(date_time_tzid.clone().into()));
+    }
+
+    #[test]
     fn get_dates_naive() {
         let naive_date = NaiveDate::from_ymd(2001, 3, 13);
         let event = Event::new().starts(naive_date).ends(naive_date).done();

--- a/src/components.rs
+++ b/src/components.rs
@@ -159,12 +159,9 @@ pub trait Component {
     /// Set the [`DTSTART`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.4) [`Property`]
     /// and [`DTEND`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.2) [`Property`],
     /// date only
-    fn all_day<TZ: TimeZone>(&mut self, date: Date<TZ>) -> &mut Self
-    where
-        TZ::Offset: fmt::Display,
-    {
-        self.append_property(naive_date_to_property(date.naive_local(), "DTSTART"))
-            .append_property(naive_date_to_property(date.naive_local(), "DTEND"))
+    fn all_day(&mut self, date: NaiveDate) -> &mut Self {
+        self.append_property(naive_date_to_property(date, "DTSTART"))
+            .append_property(naive_date_to_property(date, "DTEND"))
     }
 
     /// Defines the relative priority.

--- a/src/components.rs
+++ b/src/components.rs
@@ -156,23 +156,6 @@ pub trait Component {
         self.append_property(calendar_dt.to_property("DTEND"))
     }
 
-    /// Set the [`DTSTART`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.4) [`Property`], date only
-    fn start_date<TZ: TimeZone>(&mut self, date: Date<TZ>) -> &mut Self
-    where
-        TZ::Offset: fmt::Display,
-    {
-        // DTSTART
-        self.append_property(naive_date_to_property(date.naive_local(), "DTSTART"))
-    }
-
-    /// Set the [`DTEND`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.2) [`Property`], date only
-    fn end_date<TZ: TimeZone>(&mut self, date: Date<TZ>) -> &mut Self
-    where
-        TZ::Offset: fmt::Display,
-    {
-        self.append_property(naive_date_to_property(date.naive_local(), "DTEND"))
-    }
-
     /// Set the [`DTSTART`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.4) [`Property`]
     /// and [`DTEND`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.2) [`Property`],
     /// date only

--- a/src/components/date_time.rs
+++ b/src/components/date_time.rs
@@ -11,6 +11,10 @@ pub(crate) fn parse_utc_date_time(s: &str) -> Option<DateTime<Utc>> {
     Utc.datetime_from_str(s, UTC_DATE_TIME_FORMAT).ok()
 }
 
+pub(crate) fn format_utc_date_time(utc_dt: DateTime<Utc>) -> String {
+    utc_dt.format(UTC_DATE_TIME_FORMAT).to_string()
+}
+
 pub(crate) fn naive_date_to_property(date: NaiveDate, key: &str) -> Property {
     Property::new(key, &date.format(NAIVE_DATE_FORMAT).to_string())
         .append_parameter(ValueType::Date)

--- a/src/components/todo.rs
+++ b/src/components/todo.rs
@@ -55,7 +55,7 @@ impl Todo {
     /// Per [RFC 5545, Section 3.8.2.1](https://tools.ietf.org/html/rfc5545#section-3.8.2.1), this
     /// must be a date-time in UTC format.
     pub fn completed(&mut self, dt: DateTime<Utc>) -> &mut Self {
-        self.add_property("COMPLETED", &CalendarDateTime::Utc(dt).to_string())
+        self.add_property("COMPLETED", &format_utc_date_time(dt))
     }
 
     /// Gets the [`COMPLETED`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.1) property

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!     .done();
 //!
 //! let bday = Event::new()
-//!     .all_day(Utc.ymd(2016, 3, 15))
+//!     .all_day(NaiveDate::from_ymd(2016, 3, 15))
 //!     .summary("My Birthday")
 //!     .description(
 //! r#"Hey, I'm gonna have a party

--- a/src/parser/components.rs
+++ b/src/parser/components.rs
@@ -29,8 +29,7 @@ use pretty_assertions::assert_eq;
 
 use crate::{
     calendar::CalendarComponent,
-    components::{InnerComponent, Other},
-    CalendarDateTime,
+    components::{date_time::format_utc_date_time, InnerComponent, Other},
 };
 
 /// The parsing equivalent of [`crate::components::Component`]
@@ -68,8 +67,8 @@ pub(crate) trait LikeComponent<'a> {
                 .iter()
                 .any(|property| property.name == "DTSTAMP")
             {
-                let now = CalendarDateTime::Utc(Utc::now());
-                write_crlf!(out, "DTSTAMP:{}", now)?;
+                let now = Utc::now();
+                write_crlf!(out, "DTSTAMP:{}", format_utc_date_time(now))?;
             }
 
             if !self

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -19,6 +19,16 @@ impl Parameter {
             val: val.to_owned(),
         }
     }
+
+    /// Returns a reference to the key field.
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    /// Returns a reference to the value field.
+    pub fn value(&self) -> &str {
+        &self.val
+    }
 }
 
 //type EntryParameters = Vec<Parameter>;
@@ -47,7 +57,7 @@ impl Property {
         &self.key
     }
 
-    /// Returns a reference to the key field.
+    /// Returns a reference to the value field.
     pub fn value(&self) -> &str {
         &self.val
     }

--- a/tests/try_into_string.rs
+++ b/tests/try_into_string.rs
@@ -5,8 +5,8 @@ use std::convert::TryInto;
 #[test]
 fn try_into_string() -> Result<(), Box<dyn std::error::Error>> {
     let bday = Event::new()
-        .start_date(Utc.ymd(2016, 3, 15))
-        .end_date(Utc.ymd(2016, 3, 15))
+        .starts(NaiveDate::from_ymd(2016, 3, 15))
+        .ends(NaiveDate::from_ymd(2016, 3, 15))
         .summary("My Birthday")
         .description(
             r#"Hey, I'm gonna have a party


### PR DESCRIPTION
This fixes some issues and adds some new functionality. In particular:

* `start_date` and `end_date` were taking a date with a timezone, but then ignoring the timezone. I've removed them, and instead changed `starts` and `ends` to take `impl Into<DatePerhapsTime>`, which includes the `NaiveDate` case.
* Similarly, I've changed `all_day` to take a `NaiveDate` rather than a date with a timezone which is then ignored.
* According to RFC5545, DTSTAMP must be in UTC, but the `timestamp` method was accepting a `impl Into<CalendarDateTime>`. I've fixed this to only allow `DateTime<Utc>` to match the spec, and similarly fixed the getter to return the same.
* I've added support for setting and getting date-time values with a TZID. For now the TZID is just a string, so the client needs to handle `VTIMEZONE` components manually. I'm not sure if there's a better solution to this, I can't think of one without major changes to the API.