### PR TITLE
Publish docs for ParseString

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -37,6 +37,7 @@ mod utils;
 pub use calendar::Calendar;
 pub use components::Component;
 pub use parameters::Parameter;
+pub use parsed_string::ParseString;
 pub use properties::Property;
 
 use components::*;

--- a/src/parser/parsed_string.rs
+++ b/src/parser/parsed_string.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+/// A zero-copy string parsed from an iCal input.
 #[derive(Debug, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ParseString<'a>(Cow<'a, str>);


### PR DESCRIPTION
This small change ensures `ParseString` is included in the generated docs,
which is mostly useful for newcomers like myself.
