### PR TITLE
Convert parsed properties into DatePerhapsTime

### DIFF
--- a/src/parser/calendar.rs
+++ b/src/parser/calendar.rs
@@ -67,7 +67,7 @@ impl<'a> From<Vec<Component<'a>>> for crate::Calendar {
     }
 }
 
-impl<'a> FromStr for crate::Calendar {
+impl FromStr for crate::Calendar {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/src/parser/components.rs
+++ b/src/parser/components.rs
@@ -142,7 +142,7 @@ impl<'a> From<Component<'a>> for CalendarComponent {
     }
 }
 
-impl<'a> FromStr for CalendarComponent {
+impl FromStr for CalendarComponent {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {


### PR DESCRIPTION
This adds a helper `TryFrom` implementation to convert parsed properties
into DatePerhapsTime.

Fixes: https://github.com/hoodie/icalendar-rs/issues/44