### PR TITLE
Make Calendar components and properties public

### DIFF
--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -62,8 +62,10 @@ pub use calendar_component::CalendarComponent;
 ///
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct Calendar {
-    properties: Vec<Property>,
-    components: Vec<CalendarComponent>,
+    /// Top-level calendar properties
+    pub properties: Vec<Property>,
+    /// Events, Todos and Venues defined in the calendar
+    pub components: Vec<CalendarComponent>,
 }
 
 impl Calendar {


### PR DESCRIPTION
This allows accessing events from a calendar that has been parsed from a ICS file. Use cases include for instance deleting exiting events from a calendar.