### PR TITLE
Use AsRef<str> for find_prop

### DIFF
--- a/src/parser/components.rs
+++ b/src/parser/components.rs
@@ -51,8 +51,10 @@ impl<'a> Component<'a> {
         }
     }
 
-    pub fn find_prop(&self, name: &str) -> Option<&Property> {
-        self.properties.iter().find(|prop| prop.name == name)
+    pub fn find_prop<S: AsRef<str>>(&self, name: S) -> Option<&Property> {
+        self.properties
+            .iter()
+            .find(|prop| prop.name == name.as_ref())
     }
 }
 


### PR DESCRIPTION
This allows passing things like `String` or `CStr` and alike. Usually, it's good practice to use AsRef<str> instad of &str for fuction parameters.

See: http://xion.io/post/code/rust-string-args.html