### PR TITLE
fix: disable oldtime feature of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,13 @@ rust-version = "1.56"
 exclude = ["fixtures", ".github", ".gitignore", "*.json"]
 
 [dependencies]
-chrono = "0.4"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
+
+[dependencies.chrono]
+version = "0.4"
+default_features = false
+features = ["clock", "std", "wasmbind"]
 
 [dependencies.nom]
 version = "7"


### PR DESCRIPTION
on main:
```
Crate:     time
Version:   0.1.44
Title:     Potential segfault in the time crate
Date:      2020-11-18
ID:        RUSTSEC-2020-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0071
Solution:  Upgrade to >=0.2.23
Dependency tree:
time 0.1.44
└── chrono 0.4.22
    └── icalendar 0.13.1

error: 1 vulnerability found!
```

This removes the oldtime feature of chrono and fixes `cargo audit`