### PR TITLE
Remove pretty_assertions dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ parser = ["nom"]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 iso8601 = "0.5"
-pretty_assertions = "1"
 
 [dependencies.chrono]
 version = "0.4"


### PR DESCRIPTION
The `pretty_assertions` crate is both a dev and a non-dev dependency. At the same time, it's only actually ever used in test code. Hence, remove the non-dev dependency, as it is unused anyway.