### PR TITLE
feat: Make Calendar::property_value() publicly accessible

### DIFF
--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -92,7 +92,7 @@ impl Calendar {
     }
 
     /// Gets the value of a property.
-    fn property_value(&self, key: &str) -> Option<&str> {
+    pub fn property_value(&self, key: &str) -> Option<&str> {
         Some(
             self.properties
                 .iter()


### PR DESCRIPTION
There does not seem to be a good reason for making the `Calendar::property_value()` method private: the accessed property array is public anyway and it is nothing more than a helper. What's more, calendar components have exactly a method of this name (fulfilling a similar purpose) publicly available.
Declare it as public to make it accessible to users, instead of forcing them to copy and paste it.