### PR TITLE
docs: update references to renamed parser functions

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8,8 +8,8 @@
 //! For this reason parsing iCal is a bit indirect.
 //! In this module you find the following functions to parser iCalendar document.
 //! `unfold()` will unfold the iCal content and turn it into the nice machine-readable format it ought to be.
-//! `read_calendar()` returns a Vector of `Component`s
-//! `read_calendar_verbose()` does the same thing but produces nicer parsing errors with line numbers (referencing the normalized content).
+//! `read_calendar_simple()` returns a Vector of `Component`s
+//! `read_calendar()` does the same thing but produces nicer parsing errors with line numbers (referencing the normalized content).
 //!
 //! You don't have to use `normalize()` on your document if your calendar does not obey the folding rules specified in [rfc5545 3.1].
 //! If it unexpectedly does, the errors might be a tad confusing.


### PR DESCRIPTION
Went looking for read_calendar_verbose() when I saw this comment. Seems like the update was missed in 519c4851a34daed31e109348f96acad18408eeda