### PR TITLE
fix: support for multi-properties

### DIFF
--- a/src/components/other.rs
+++ b/src/components/other.rs
@@ -25,7 +25,7 @@ impl Component for Other {
     }
 
     /// Read-only access to `multi_properties`
-    fn multi_properties(&self) -> &Vec<Property> {
+    fn multi_properties(&self) -> &BTreeMap<String, Vec<Property>> {
         &self.inner.multi_properties
     }
 
@@ -40,7 +40,7 @@ impl Component for Other {
 
     /// Adds a `Property` of which there may be many
     fn append_multi_property(&mut self, property: impl Into<Property>) -> &mut Self {
-        self.inner.multi_properties.push(property.into());
+        self.inner.insert_multi(property);
         self
     }
 

--- a/src/parser/properties.rs
+++ b/src/parser/properties.rs
@@ -23,6 +23,25 @@ use nom::{
 #[cfg(test)]
 use nom::error::ErrorKind;
 
+/// [RFC-5545](https://datatracker.ietf.org/doc/html/rfc5545) states that the following
+/// "MAY occur more than once" in a VEVENT, VTODO, VJOURNAL, and VFREEBUSY.
+/// Note: A VJOURNAL can also contain multiple DECRIPTION but this is not covered here.
+const MULTIS: [&str; 13] = [
+    "ATTACH",
+    "ATTENDEE",
+    "CATEGORIES",
+    "COMMENT",
+    "CONTACT",
+    "EXDATE",
+    "FREEBUSY",
+    "IANA-PROP",
+    "RDATE",
+    "RELATED",
+    "RESOURCES",
+    "RSTATUS",
+    "X-PROP",
+];
+
 /// Zero-copy version of [`crate::properties::Property`]
 #[derive(PartialEq, Eq, Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -58,6 +77,10 @@ impl Property<'_> {
         write!(line, ":{}", self.val.as_str())?;
         write_crlf!(out, "{}", fold_line(&line))?;
         Ok(())
+    }
+
+    pub(crate) fn is_multi_property(&self) -> bool {
+        MULTIS.contains(&self.name.as_str())
     }
 }
 


### PR DESCRIPTION
WIP: Add support for multi-properties in calendar parsing.
- Updated InnerComponent multi_property from Vec<Property> to BTreeMap<String, Vec<Property>>
- When converting into InnerComponent, split the properties by those that "May occur more than once" and all others
- Added a basic test as proof of concept
- Still to do is add filtering for other properties such as attach, cattegory, etc.