### PR TITLE
Initial commit for the introduction of the iCalendar-Duration struct.

### DIFF
--- a/examples/alarm.rs
+++ b/examples/alarm.rs
@@ -1,12 +1,12 @@
-use chrono::*;
+use chrono::{Utc, Duration as ChronoDuration, };
 use icalendar::*;
 
 fn main() {
     let mut calendar = Calendar::new();
 
     let now = Utc::now();
-    let soon = Utc::now() + Duration::minutes(12);
-    let tomorrow = Utc::now() + Duration::days(1);
+    let soon = Utc::now() + ChronoDuration::minutes(12);
+    let tomorrow = Utc::now() + ChronoDuration::days(1);
 
     let todo_test_audio = Todo::new()
         .summary("TODO with audio alarm -15min")
@@ -17,22 +17,22 @@ fn main() {
         .percent_complete(98)
         .alarm(
             Alarm::audio(-Duration::minutes(10))
-                .duration_and_repeat(chrono::Duration::minutes(1), 4),
+                .duration_and_repeat(Duration::minutes(1), 4),
         )
         .done();
 
     let event_test_display = Event::new()
         .summary("test event")
         .description("here I have something really important to do")
-        .starts(Utc::now() + Duration::minutes(5))
+        .starts(Utc::now() + ChronoDuration::minutes(5))
         .class(Class::Confidential)
-        .ends(Utc::now() + Duration::hours(1))
+        .ends(Utc::now() + ChronoDuration::hours(1))
         .alarm(
             Alarm::display(
-                "you should test your implementation",
-                Utc::now() + Duration::minutes(1),
+                        "you should test your implementation",
+                Utc::now() + ChronoDuration::minutes(1),
             )
-            .duration_and_repeat(chrono::Duration::minutes(1), 4),
+            .duration_and_repeat(Duration::minutes(1), 4),
         )
         .done();
 
@@ -44,10 +44,10 @@ fn main() {
         .status(TodoStatus::NeedsAction)
         .alarm(
             Alarm::display(
-                "you should test your implementation",
-                (-Duration::minutes(10), Related::End),
+                        "you should test your implementation",
+                        (-Duration::minutes(10), Related::End),
             )
-            .duration_and_repeat(chrono::Duration::minutes(1), 4),
+            .duration_and_repeat(Duration::minutes(1), 4),
         )
         .done();
 
@@ -58,8 +58,8 @@ fn main() {
         .due(tomorrow)
         .status(TodoStatus::NeedsAction)
         .alarm(
-            Alarm::audio(now + Duration::minutes(1))
-                .duration_and_repeat(chrono::Duration::minutes(1), 4),
+            Alarm::audio(now + ChronoDuration::minutes(1))
+                .duration_and_repeat(Duration::minutes(1), 4),
         )
         .done();
 

--- a/examples/alarm.rs
+++ b/examples/alarm.rs
@@ -1,12 +1,12 @@
-use chrono::{Utc, Duration as ChronoDuration, };
+use chrono::*;
 use icalendar::*;
 
 fn main() {
     let mut calendar = Calendar::new();
 
     let now = Utc::now();
-    let soon = Utc::now() + ChronoDuration::minutes(12);
-    let tomorrow = Utc::now() + ChronoDuration::days(1);
+    let soon = Utc::now() + chrono::Duration::minutes(12);
+    let tomorrow = Utc::now() + chrono::Duration::days(1);
 
     let todo_test_audio = Todo::new()
         .summary("TODO with audio alarm -15min")
@@ -16,23 +16,23 @@ fn main() {
         .status(TodoStatus::NeedsAction)
         .percent_complete(98)
         .alarm(
-            Alarm::audio(-Duration::minutes(10))
-                .duration_and_repeat(Duration::minutes(1), 4),
+            Alarm::audio(-icalendar::Duration::minutes(10))
+                .duration_and_repeat(icalendar::Duration::minutes(1), 4),
         )
         .done();
 
     let event_test_display = Event::new()
         .summary("test event")
         .description("here I have something really important to do")
-        .starts(Utc::now() + ChronoDuration::minutes(5))
+        .starts(Utc::now() + chrono::Duration::minutes(5))
         .class(Class::Confidential)
-        .ends(Utc::now() + ChronoDuration::hours(1))
+        .ends(Utc::now() + chrono::Duration::hours(1))
         .alarm(
             Alarm::display(
                         "you should test your implementation",
-                Utc::now() + ChronoDuration::minutes(1),
+                Utc::now() + chrono::Duration::minutes(1),
             )
-            .duration_and_repeat(Duration::minutes(1), 4),
+            .duration_and_repeat(icalendar::Duration::minutes(1), 4),
         )
         .done();
 
@@ -45,9 +45,9 @@ fn main() {
         .alarm(
             Alarm::display(
                         "you should test your implementation",
-                        (-Duration::minutes(10), Related::End),
+                        (-icalendar::Duration::minutes(10), Related::End),
             )
-            .duration_and_repeat(Duration::minutes(1), 4),
+            .duration_and_repeat(icalendar::Duration::minutes(1), 4),
         )
         .done();
 
@@ -58,8 +58,8 @@ fn main() {
         .due(tomorrow)
         .status(TodoStatus::NeedsAction)
         .alarm(
-            Alarm::audio(now + ChronoDuration::minutes(1))
-                .duration_and_repeat(Duration::minutes(1), 4),
+            Alarm::audio(now + chrono::Duration::minutes(1))
+                .duration_and_repeat(icalendar::Duration::minutes(1), 4),
         )
         .done();
 

--- a/examples/alarm_minimal.rs
+++ b/examples/alarm_minimal.rs
@@ -1,11 +1,11 @@
-use chrono::*;
+use chrono::{Utc, Duration as ChronoDuration};
 use icalendar::*;
 
 fn main() {
     // alarm will occur one minute from now
     let event_with_absolute_audio_alarm = Event::new()
         .alarm(
-            Alarm::audio(Utc::now() + Duration::minutes(1))
+            Alarm::audio(Utc::now() + ChronoDuration::minutes(1))
                 .duration_and_repeat(Duration::minutes(1), 4),
         )
         .done();

--- a/examples/alarm_minimal.rs
+++ b/examples/alarm_minimal.rs
@@ -1,27 +1,27 @@
-use chrono::{Utc, Duration as ChronoDuration};
+use chrono::*;
 use icalendar::*;
 
 fn main() {
     // alarm will occur one minute from now
     let event_with_absolute_audio_alarm = Event::new()
         .alarm(
-            Alarm::audio(Utc::now() + ChronoDuration::minutes(1))
-                .duration_and_repeat(Duration::minutes(1), 4),
+            Alarm::audio(Utc::now() + chrono::Duration::minutes(1))
+                .duration_and_repeat(icalendar::Duration::minutes(1), 4),
         )
         .done();
 
     // alarm will occur one minute before the start
     let event_with_relative_display_alarm = Event::new()
         .alarm(
-            Alarm::display("ALARM! ALARM!", -Duration::minutes(1))
-                .duration_and_repeat(Duration::minutes(1), 4),
+            Alarm::display("ALARM! ALARM!", -icalendar::Duration::minutes(1))
+                .duration_and_repeat(icalendar::Duration::minutes(1), 4),
         )
         .done();
     // alarm will occur one minute before the end
     let event_with_relative_display_alarm_end = Event::new()
         .alarm(
-            Alarm::display("ALARM! ALARM!", (-Duration::minutes(1), Related::End))
-                .duration_and_repeat(Duration::minutes(1), 4),
+            Alarm::display("ALARM! ALARM!", (-icalendar::Duration::minutes(1), Related::End))
+                .duration_and_repeat(icalendar::Duration::minutes(1), 4),
         )
         .done();
     event_with_absolute_audio_alarm.print().unwrap();

--- a/examples/full_circle.rs
+++ b/examples/full_circle.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "parser")]
 use std::str::FromStr;
 
-use chrono::{Utc, Duration as ChronoDuration};
+use chrono::*;
 use icalendar::parser;
 use icalendar::*;
 
@@ -11,7 +11,7 @@ fn main() {
         .description("here I have something really important to do")
         .starts(Utc::now())
         .class(Class::Confidential)
-        .ends(Utc::now() + ChronoDuration::days(1))
+        .ends(Utc::now() + chrono::Duration::days(1))
         .append_property(
             Property::new("TEST", "FOOBAR")
                 .add_parameter("IMPORTANCE", "very")

--- a/examples/full_circle.rs
+++ b/examples/full_circle.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "parser")]
 use std::str::FromStr;
 
-use chrono::*;
+use chrono::{Utc, Duration as ChronoDuration};
 use icalendar::parser;
 use icalendar::*;
 
@@ -11,7 +11,7 @@ fn main() {
         .description("here I have something really important to do")
         .starts(Utc::now())
         .class(Class::Confidential)
-        .ends(Utc::now() + Duration::days(1))
+        .ends(Utc::now() + ChronoDuration::days(1))
         .append_property(
             Property::new("TEST", "FOOBAR")
                 .add_parameter("IMPORTANCE", "very")

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,4 +1,4 @@
-use chrono::{Utc, NaiveDate, Duration as ChronoDuration};
+use chrono::*;
 #[cfg(feature = "chrono-tz")]
 use chrono_tz::Europe::Berlin;
 use icalendar::*;
@@ -14,7 +14,7 @@ fn main() {
                 .description("here I have something really important to do")
                 .starts(Utc::now())
                 .class(Class::Confidential)
-                .ends(Utc::now() + ChronoDuration::days(1))
+                .ends(Utc::now() + chrono::Duration::days(1))
                 .append_property(
                     Property::new("TEST", "FOOBAR")
                         .add_parameter("IMPORTANCE", "very")

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,4 +1,4 @@
-use chrono::*;
+use chrono::{Utc, NaiveDate, Duration as ChronoDuration};
 #[cfg(feature = "chrono-tz")]
 use chrono_tz::Europe::Berlin;
 use icalendar::*;
@@ -14,7 +14,7 @@ fn main() {
                 .description("here I have something really important to do")
                 .starts(Utc::now())
                 .class(Class::Confidential)
-                .ends(Utc::now() + Duration::days(1))
+                .ends(Utc::now() + ChronoDuration::days(1))
                 .append_property(
                     Property::new("TEST", "FOOBAR")
                         .add_parameter("IMPORTANCE", "very")

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -1,4 +1,4 @@
-use chrono::*;
+use chrono::{Local, Utc, Duration as ChronoDuration};
 use icalendar::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .summary("buy groceries")
         .description("* soy-milk\n* oak-meal\n* vegan chocolate\n* kale\n* bacon\nabcdefghijklmnopqrstuvwxyz")
         .starts(Local::now().naive_local())
-        .ends(Local::now().naive_local() + Duration::hours(24))
+        .ends(Local::now().naive_local() + ChronoDuration::hours(24))
         .priority(12)
         .percent_complete(28)
         .status(TodoStatus::InProcess)

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -1,4 +1,4 @@
-use chrono::{Local, Utc, Duration as ChronoDuration};
+use chrono::*;
 use icalendar::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .summary("buy groceries")
         .description("* soy-milk\n* oak-meal\n* vegan chocolate\n* kale\n* bacon\nabcdefghijklmnopqrstuvwxyz")
         .starts(Local::now().naive_local())
-        .ends(Local::now().naive_local() + ChronoDuration::hours(24))
+        .ends(Local::now().naive_local() + chrono::Duration::hours(24))
         .priority(12)
         .percent_complete(28)
         .status(TodoStatus::InProcess)

--- a/src/components.rs
+++ b/src/components.rs
@@ -7,6 +7,7 @@ use crate::properties::*;
 use date_time::{format_utc_date_time, naive_date_to_property, parse_utc_date_time};
 
 pub mod alarm;
+pub mod duration;
 pub(crate) mod date_time;
 mod event;
 mod other;
@@ -15,6 +16,7 @@ mod venue;
 
 use alarm::*;
 use date_time::{CalendarDateTime, DatePerhapsTime};
+pub use duration::*;
 pub use event::*;
 pub use other::*;
 pub use todo::*;

--- a/src/components/alarm.rs
+++ b/src/components/alarm.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt::Debug, str::FromStr};
 
-pub use self::properties::{Related, Trigger, Duration};
+pub use self::properties::{Related, Trigger};
 
 use self::properties::*;
 use super::*;
@@ -281,8 +281,6 @@ fn test_email() {
 
 pub mod properties {
 
-    use std::{fmt::Display, ops::Neg};
-
     use crate::components::alarm::properties::Parameter;
 
     use self::date_time::parse_duration;
@@ -403,178 +401,6 @@ pub mod properties {
             Property::from(Repeat::default()).try_into(),
             Ok(String::from("REPEAT:0\r\n"))
         )
-    }
-
-    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-    pub struct Duration {
-        positive: bool,
-        weeks: u64,
-        days: u64,
-        hours: u64,
-        minutes: u64,
-        seconds: u64
-    }
-
-    impl Default for Duration {
-        fn default() -> Self {
-            Self {
-                positive: true,
-                weeks:0,
-                days:0,
-                hours:0,
-                minutes:0,
-                seconds:0
-            }
-        }
-    }
-
-    #[allow(dead_code)]
-    impl Duration {
-        pub fn new(positive: bool, weeks: u64, days: u64, hours: u64, minutes: u64, seconds: u64) -> Self {
-            Self{positive, weeks, days, hours, minutes, seconds}
-        }
-        
-        pub fn weeks(weeks: u64) -> Self {
-            Self {
-                weeks,
-                ..Self::default()
-            }
-        }
-
-        pub fn days(days: u64) -> Self {
-            Self {
-                days,
-                ..Self::default()
-            }
-        }
-
-        pub fn hours(hours:u64) -> Self {
-            Self {
-                hours,
-                ..Self::default()
-            }
-        }
-
-        pub fn minutes(minutes: u64) -> Self {
-            Self {
-                minutes,
-                ..Self::default()
-            }
-        }
-
-        pub fn seconds(seconds: u64) -> Self {
-            Self {
-                seconds,
-                ..Self::default()
-            }
-        }
-    }
-
-    impl Neg for Duration {
-        type Output = Duration;
-    
-        fn neg(self) -> Self::Output {
-            Self {
-                positive: !self.positive,
-                ..self
-            }
-        }
-    }
-
-    impl FromStr for Duration {
-        type Err = ();
-    
-        fn from_str(s: &str) -> Result<Self, Self::Err> {
-            if s.is_empty() {
-                return Err(())
-            }
-            let mut positiv:bool = true;
-
-            let mut it = s.chars();
-            let first = it.next();
-            if let Some(first) = first {
-                if first == '-' {
-                    positiv = false;
-                } 
-            }
-            
-            let parsed = if positiv {
-                iso8601::duration(s)
-            } else {
-                iso8601::duration(it.as_str())
-            };
-
-            if let Ok(parsed) = parsed {
-                let parsed = Duration::try_from(parsed)?;
-
-                if !positiv {
-                    Ok(-parsed)
-                } else {
-                    Ok(parsed)
-                }
-                
-            } else {
-                Err(())
-            }
-        }
-        
-    }
-
-    impl TryFrom<iso8601::Duration> for Duration {
-        type Error = ();
-    
-        fn try_from(value: iso8601::Duration) -> Result<Self, Self::Error> {
-            // What happens if the format is P1W1D? 
-            // I think this didnt work before either
-            match value {
-                iso8601::Duration::YMDHMS { year, month, day, hour, minute, second, millisecond: _ } => {
-                    if (year | month ) > 0 {
-                        // Its not allowed to have year or month specifiers for ics files 
-                        // https://icalendar.org/iCalendar-RFC-5545/3-3-6-duration.html
-                        return Err(())
-                    } 
-                    Ok(Self::new(true, 0, day as u64, hour as u64, minute as u64, second as u64))
-                },
-                iso8601::Duration::Weeks(weeks) => Ok(Self::weeks(weeks as u64)),
-            }          
-        }
-    }
-
-    impl From<Duration> for Property {
-        fn from(value: Duration) -> Self {
-            Property::new_pre_alloc("DURATION".into(), value.to_string())
-        }
-    }
-
-
-    impl Display for Duration {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            if !self.positive {
-                f.write_str("-")?;
-            }
-            f.write_str("P")?;
-
-            if self.weeks > 0 {
-                f.write_fmt(format_args!("{}W", self.weeks))?;
-            }
-            if self.days > 0 {
-                f.write_fmt(format_args!("{}D", self.days))?;
-            }
-            if (self.hours | self.minutes | self.seconds) > 0 {
-                f.write_str("T")?;
-                if self.hours > 0 {
-                    f.write_fmt(format_args!("{}H", self.hours))?;
-                }
-                if self.minutes > 0 {
-                    f.write_fmt(format_args!("{}M", self.minutes))?;
-                }
-                if self.seconds > 0 {
-                    f.write_fmt(format_args!("{}S", self.seconds))?;
-                }
-            }
-
-            Ok(())
-        }
     }
 
     /// Describes when an alarm is supposed to occure.
@@ -805,26 +631,6 @@ pub mod properties {
         pretty_assertions::assert_eq!(
             alarm_with_rel_start_trigger.get_trigger(),
             Some(Trigger::Duration(dur, Some(Related::Start)))
-        );
-    }
-
-    #[test]
-    fn test_duration_parse_full_positiv() {
-        let dur_str = "P1DT1H1M1S";
-        
-        pretty_assertions::assert_eq!(
-            Duration::from_str(dur_str).unwrap().to_string(),
-            dur_str
-        );
-    }
-
-    #[test]
-    fn test_duration_parse_full_negativ() {
-        let dur_str = "-P1DT1H1M1S";
-
-        pretty_assertions::assert_eq!(
-            Duration::from_str(dur_str).unwrap().to_string(),
-            dur_str
         );
     }
 

--- a/src/components/date_time.rs
+++ b/src/components/date_time.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, unused)]
 use std::str::FromStr;
 
-use chrono::{Date, DateTime, Duration as ChronoDuration, NaiveDate, NaiveDateTime, Offset, TimeZone as _, Utc};
+use chrono::{Date, DateTime, NaiveDate, NaiveDateTime, Offset, TimeZone as _, Utc};
 
 use crate::{Property, ValueType};
 

--- a/src/components/date_time.rs
+++ b/src/components/date_time.rs
@@ -5,7 +5,7 @@ use chrono::{Date, DateTime, NaiveDate, NaiveDateTime, Offset, TimeZone as _, Ut
 
 use crate::{Property, ValueType};
 
-use super::properties::Duration;
+use super::Duration;
 
 const NAIVE_DATE_TIME_FORMAT: &str = "%Y%m%dT%H%M%S";
 const UTC_DATE_TIME_FORMAT: &str = "%Y%m%dT%H%M%SZ";

--- a/src/components/date_time.rs
+++ b/src/components/date_time.rs
@@ -1,9 +1,11 @@
 #![allow(dead_code, unused)]
 use std::str::FromStr;
 
-use chrono::{Date, DateTime, Duration, NaiveDate, NaiveDateTime, Offset, TimeZone as _, Utc};
+use chrono::{Date, DateTime, Duration as ChronoDuration, NaiveDate, NaiveDateTime, Offset, TimeZone as _, Utc};
 
 use crate::{Property, ValueType};
+
+use super::properties::Duration;
 
 const NAIVE_DATE_TIME_FORMAT: &str = "%Y%m%dT%H%M%S";
 const UTC_DATE_TIME_FORMAT: &str = "%Y%m%dT%H%M%SZ";
@@ -23,9 +25,7 @@ pub(crate) fn format_utc_date_time(utc_dt: DateTime<Utc>) -> String {
 }
 
 pub(crate) fn parse_duration(s: &str) -> Option<Duration> {
-    iso8601::duration(s)
-        .ok()
-        .and_then(|iso| Duration::from_std(iso.into()).ok())
+    Duration::from_str(s).ok()
 }
 
 pub(crate) fn naive_date_to_property(date: NaiveDate, key: &str) -> Property {

--- a/src/components/duration.rs
+++ b/src/components/duration.rs
@@ -1,0 +1,229 @@
+use std::{fmt::{self, Display}, ops::Neg, str::FromStr};
+
+use crate::Property;
+
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Duration {
+    positive: bool,
+    weeks: u64,
+    days: u64,
+    hours: u64,
+    minutes: u64,
+    seconds: u64
+}
+
+impl Default for Duration {
+    fn default() -> Self {
+        Self {
+            positive: true,
+            weeks:0,
+            days:0,
+            hours:0,
+            minutes:0,
+            seconds:0
+        }
+    }
+}
+
+impl Duration {
+    pub fn new(positive: bool, weeks: u64, days: u64, hours: u64, minutes: u64, seconds: u64) -> Self {
+        Self{positive, weeks, days, hours, minutes, seconds}
+    }
+    
+    pub fn weeks(weeks: u64) -> Self {
+        Self {
+            weeks,
+            ..Self::default()
+        }
+    }
+
+    pub fn days(days: u64) -> Self {
+        Self {
+            days,
+            ..Self::default()
+        }
+    }
+
+    pub fn hours(hours:u64) -> Self {
+        Self {
+            hours,
+            ..Self::default()
+        }
+    }
+
+    pub fn minutes(minutes: u64) -> Self {
+        Self {
+            minutes,
+            ..Self::default()
+        }
+    }
+
+    pub fn seconds(seconds: u64) -> Self {
+        Self {
+            seconds,
+            ..Self::default()
+        }
+    }
+
+    pub fn and_weeks(mut self, weeks: u64) -> Self {
+        self.weeks = weeks;
+        self
+    }
+
+    pub fn and_days(mut self, days: u64) -> Self {
+        self.days = days;
+        self
+    }
+
+    pub fn and_hours(mut self, hours: u64) -> Self {
+        self.hours = hours;
+        self
+    }
+
+    pub fn and_minutes(mut self, minutes: u64) -> Self {
+        self.minutes = minutes;
+        self
+    }
+
+    pub fn and_seconds(mut self, seconds: u64) -> Self {
+        self.seconds = seconds;
+        self
+    }
+}
+
+impl Neg for Duration {
+    type Output = Duration;
+
+    fn neg(self) -> Self::Output {
+        Self {
+            positive: !self.positive,
+            ..self
+        }
+    }
+}
+
+impl FromStr for Duration {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(())
+        }
+        let mut positiv:bool = true;
+
+        let mut it = s.chars();
+        let first = it.next();
+        if let Some(first) = first {
+            if first == '-' {
+                positiv = false;
+            } 
+        }
+        
+        let parsed = if positiv {
+            iso8601::duration(s)
+        } else {
+            iso8601::duration(it.as_str())
+        };
+
+        if let Ok(parsed) = parsed {
+            let parsed = Duration::try_from(parsed)?;
+
+            if !positiv {
+                Ok(-parsed)
+            } else {
+                Ok(parsed)
+            }
+            
+        } else {
+            Err(())
+        }
+    }
+    
+}
+
+impl TryFrom<iso8601::Duration> for Duration {
+    type Error = ();
+
+    fn try_from(value: iso8601::Duration) -> Result<Self, Self::Error> {
+        // What happens if the format is P1W1D? 
+        // I think this didnt work before either
+        match value {
+            iso8601::Duration::YMDHMS { year, month, day, hour, minute, second, millisecond: _ } => {
+                if (year | month ) > 0 {
+                    // Its not allowed to have year or month specifiers for ics files 
+                    // https://icalendar.org/iCalendar-RFC-5545/3-3-6-duration.html
+                    return Err(())
+                } 
+                Ok(Self::new(true, 0, day as u64, hour as u64, minute as u64, second as u64))
+            },
+            iso8601::Duration::Weeks(weeks) => Ok(Self::weeks(weeks as u64)),
+        }          
+    }
+}
+
+impl From<Duration> for Property {
+    fn from(value: Duration) -> Self {
+        Property::new_pre_alloc("DURATION".into(), value.to_string())
+    }
+}
+
+
+impl Display for Duration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if !self.positive {
+            f.write_str("-")?;
+        }
+        f.write_str("P")?;
+
+        if self.weeks > 0 {
+            f.write_fmt(format_args!("{}W", self.weeks))?;
+        }
+        if self.days > 0 {
+            f.write_fmt(format_args!("{}D", self.days))?;
+        }
+        if (self.hours | self.minutes | self.seconds) > 0 {
+            f.write_str("T")?;
+            if self.hours > 0 {
+                f.write_fmt(format_args!("{}H", self.hours))?;
+            }
+            if self.minutes > 0 {
+                f.write_fmt(format_args!("{}M", self.minutes))?;
+            }
+            if self.seconds > 0 {
+                f.write_fmt(format_args!("{}S", self.seconds))?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[test]
+fn test_duration_parse_full_positiv() {
+    let dur_str = "P1DT1H1M1S";
+    
+    pretty_assertions::assert_eq!(
+        Duration::from_str(dur_str).unwrap().to_string(),
+        dur_str
+    );
+}
+
+#[test]
+fn test_duration_parse_full_negativ() {
+    let dur_str = "-P1DT1H1M1S";
+
+    pretty_assertions::assert_eq!(
+        Duration::from_str(dur_str).unwrap().to_string(),
+        dur_str
+    );
+}
+
+#[test]
+fn test_duration_create_and_weeks() {
+    let dur = Duration::days(1).and_weeks(1);
+    
+    pretty_assertions::assert_eq!(
+        dur.to_string(), "P1W1D"
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ mod properties;
 pub use crate::{
     calendar::{Calendar, CalendarComponent},
     components::{
-        alarm::{Alarm, Related, Trigger},
+        alarm::{Alarm, Related, Trigger, Duration},
         date_time::{CalendarDateTime, DatePerhapsTime},
         Component, Event, EventLike, Todo, Venue,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,9 +104,9 @@ mod properties;
 pub use crate::{
     calendar::{Calendar, CalendarComponent},
     components::{
-        alarm::{Alarm, Related, Trigger, Duration},
+        alarm::{Alarm, Related, Trigger},
         date_time::{CalendarDateTime, DatePerhapsTime},
-        Component, Event, EventLike, Todo, Venue,
+        Component, Event, EventLike, Todo, Venue, Duration
     },
     properties::{Class, EventStatus, Parameter, Property, TodoStatus, ValueType},
 };

--- a/tests/alarm.rs
+++ b/tests/alarm.rs
@@ -20,7 +20,7 @@ UID:uid4@example.com\r
 BEGIN:VALARM\r
 ACTION:AUDIO\r
 DTSTAMP:19980130T134500Z\r
-DURATION:PT3600S\r
+DURATION:PT1H\r
 REPEAT:4\r
 TRIGGER;VALUE=DATE-TIME:19980403T120000Z\r
 UID:OverwriteForConsistency\r
@@ -47,7 +47,7 @@ fn test_alarm_to_string() {
         .summary("Submit Income Taxes")
         .append_component(
             Alarm::audio(Utc.with_ymd_and_hms(1998, 4, 3, 12, 0, 0).unwrap())
-                .duration_and_repeat(chrono::Duration::hours(1), 4)
+                .duration_and_repeat(icalendar::Duration::hours(1), 4)
                 .uid("OverwriteForConsistency")
                 .add_property("DTSTAMP", "19980130T134500Z")
                 .done(),


### PR DESCRIPTION
Hi @hoodie,

I wanted to update the parser and update the output of the property command. I read into a lot of parsing libraries and all seem to have a pretty lackluster API for creating durations. Thats why I decided to create a wrapper for the ISO8601 duration with the addition of the sign. 

I wanted to check with you if this is an approach you would agree with, before I put in to much effort with updating all the documentations. 

Missing Tasks: 
- [x] Add parsing of negative durations (`-P1D`)
- [x] Add tests
- [ ] Add documentation for `Duration`
- [ ] Update all the documentations 
