### PR TITLE
fix: escape according to value types

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -428,6 +428,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn get_url() {
+        let url = "http://hoodie.de/";
+        let event = Event::new().url(url).done();
+
+        let serialized = event.to_string();
+        let reparsed =
+            Other::from(crate::parser::Component::<'_>::try_from(serialized.as_str()).unwrap());
+
+        assert_eq!(event.get_url(), Some(url));
+        assert_eq!(reparsed.get_url(), Some(url));
+    }
+
+    #[test]
     fn get_properties_unset() {
         let event = Event::new();
         assert_eq!(event.get_priority(), None);

--- a/src/components/alarm.rs
+++ b/src/components/alarm.rs
@@ -25,7 +25,7 @@ use super::*;
 /// When it is time for the Alarm to occur we have to define what is actually supposed to happen.
 /// The RFC5545 know three different actions, two of which are currently implemented.
 ///
-/// 1. Display  
+/// 1. Display
 /// 2. Audio
 /// 3. Email (not yet implemented)
 ///

--- a/src/components/date_time.rs
+++ b/src/components/date_time.rs
@@ -1,7 +1,6 @@
-#![allow(dead_code, unused)]
 use std::str::FromStr;
 
-use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, Offset, TimeZone as _, Utc};
+use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, TimeZone as _, Utc};
 
 use crate::{Property, ValueType};
 
@@ -131,7 +130,9 @@ impl CalendarDateTime {
         }
     }
 
+    /// TODO: make public or delete
     #[cfg(feature = "chrono-tz")]
+    #[allow(dead_code)]
     pub(crate) fn with_timezone(dt: NaiveDateTime, tz_id: chrono_tz::Tz) -> Self {
         Self::WithTimezone {
             date_time: dt,
@@ -267,7 +268,9 @@ impl DatePerhapsTime {
     }
 }
 
+/// TODO: make public or delete
 #[cfg(feature = "chrono-tz")]
+#[allow(dead_code)]
 pub fn with_timezone<T: chrono::TimeZone + chrono_tz::OffsetName>(
     dt: DateTime<T>,
 ) -> DatePerhapsTime {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ mod components;
 #[cfg(feature = "parser")]
 pub mod parser;
 mod properties;
+mod value_types;
 
 pub use crate::{
     calendar::{Calendar, CalendarComponent},
@@ -108,7 +109,8 @@ pub use crate::{
         date_time::{CalendarDateTime, DatePerhapsTime},
         Component, Event, EventLike, Todo, Venue,
     },
-    properties::{Class, EventStatus, Parameter, Property, TodoStatus, ValueType},
+    properties::{Class, EventStatus, Parameter, Property, TodoStatus},
+    value_types::ValueType,
 };
 
 #[cfg(feature = "chrono-tz")]

--- a/src/parser/parsed_string.rs
+++ b/src/parser/parsed_string.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
 
+use crate::ValueType;
+
 /// A zero-copy string parsed from an iCal input.
 #[derive(Debug, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -26,6 +28,13 @@ impl ParseString<'_> {
 }
 
 impl<'a> ParseString<'a> {
+    pub fn unescape_by_value_type(self, value_type: ValueType) -> ParseString<'a> {
+        match value_type {
+            ValueType::Text => self.unescape_text(),
+            _ => self,
+        }
+    }
+
     pub fn unescape_text(self) -> ParseString<'a> {
         if self.0.contains(r#"\\"#)
             || self.0.contains(r#"\,"#)

--- a/src/value_types.rs
+++ b/src/value_types.rs
@@ -1,0 +1,137 @@
+use std::str::FromStr;
+
+use crate::Parameter;
+
+/// see 8.3.4. [Value Data Types Registry](https://tools.ietf.org/html/rfc5545#section-8.3.4)
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ValueType {
+    /// [`Binary`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.1)
+    Binary,
+    /// [`Boolean`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.2)
+    Boolean,
+    /// [`CalAddress`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.3)
+    CalAddress,
+    /// [`Date`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.4)
+    Date,
+    /// [`DateTime`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.5)
+    DateTime,
+    /// [`Duration`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.6)
+    Duration,
+    /// [`Float`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.7)
+    Float,
+    /// [`Integer`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.8)
+    Integer,
+    /// [`Period`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.9)
+    Period,
+    /// [`Recur`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10)
+    Recur,
+    /// [`Text`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.11)
+    Text,
+    /// [`Time`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.12)
+    Time,
+    /// [`Uri`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.13)
+    Uri,
+    /// [`UtcOffset`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.14)
+    UtcOffset,
+}
+
+impl ValueType {
+    pub(crate) fn by_name(name: &str) -> Option<Self> {
+        if name.chars().any(char::is_lowercase) {
+            // eprintln!("property_name must be uppercase");
+            return None;
+        }
+        use ValueType::*;
+        match name {
+            // 3.7.0 calendar properties
+            "CALSCALE" => Some(Text), // 3.7.1
+            "METHOD" => Some(Text),   // 3.7.2
+            "PRODID" => Some(Text),   // 3.7.3
+            "VERSION" => Some(Text),  //3.7.4
+
+            // 3.8.0 component properties
+            "ATTACH" => Some(Uri),               // or BINARY // 3.8.1.1
+            "CATEGORIES" => Some(Text),          // 3.8.1.2
+            "CLASS" => Some(Text),               // 3.8.1.3
+            "COMMENT" => Some(Text),             // 3.8.1.4
+            "DESCRIPTION" => Some(Text),         // 3.8.1.5
+            "GEO" => Some(Float),                // 3.8.1.6
+            "LOCATION" => Some(Text),            // 3.8.1.7
+            "PERCENT-COMPLETE" => Some(Integer), // 3.8.1.8
+            "PRIORITY" => Some(Integer),         // 3.8.1.9
+            "RESOURCES" => Some(Text),           // 3.8.1.10
+            "STATUS" => Some(Text),              // 3.8.1.11
+            "SUMMARY" => Some(Text),             // 3.8.8.1.12
+            "COMPLETED" => Some(DateTime),       // 3.8.2.1
+            "DTEND" => Some(DateTime),           // or DATE // 3.8.2.2
+            "DUE" => Some(DateTime),             // or DATE // 3.8.2.3
+            "DTSTART" => Some(DateTime),         // or DATE 3.8.2.4
+            "DURATION" => Some(Duration),        // 3.8.2.5
+            "FREEBUSY" => Some(Period),          // 3.8.2.6
+            "TRANSP" => Some(Text),              // 3.8.2.7
+            "TZID" => Some(Text),                // 3.8.3.1
+            "TZNAME" => Some(Text),              // 3.8.3.2
+            "TZOFFSETFROM" => Some(UtcOffset),   //
+            "TZOFFSETTO" => Some(UtcOffset),     //
+            "TZURL" => Some(Uri),                //
+            "ATTENDEE" => Some(CalAddress),      // 3.8.4.1
+            "CONTACT" => Some(Text),             // 3.8.4.2
+            "ORGANIZER" => Some(CalAddress),     // 3.8.4.3
+            "RECURRENCE-ID" => Some(DateTime),   // 3.8.4.4
+            "RELATED-TO" => Some(Text),          //
+            "URL" => Some(Uri),                  //
+            "UID" => Some(Text),                 //
+            "EXDATE" => Some(DateTime),          // or DATE-TIME //
+            "RDATE" => Some(DateTime),           // or PERIOD // or DATE-TIME // or DATE //
+            "RRULE" => Some(Recur),              //
+            "ACTION" => Some(Text),              //
+            "REPEAT" => Some(Integer),           //
+            "TRIGGER" => Some(Duration),         // or DATE-TIME (must be UTC) // 3.8.6.3
+            "CREATED" => Some(DateTime),         // 3.8.7.1
+            "DTSTAMP" => Some(DateTime),         //  3.8.7.2
+            "LAST-MODIFIED" => Some(DateTime),   // 3.8.7.3
+            "SEQUENCE" => Some(Integer),         // 3.8.7.4
+            // 3.8.8.1
+            // "An IANA-registered property name" => Any parameter can be specified on this property.
+            // "X-"/* ... */ => Some(Text),       // any type 3.8.8.2
+            "REQUEST-STATUS" => Some(Text), // 3.8.8.3
+            _ => None,
+        }
+    }
+}
+
+impl TryFrom<Parameter> for ValueType {
+    type Error = ();
+
+    fn try_from(par: Parameter) -> Result<Self, Self::Error> {
+        if par.key() != "VALUE" {
+            Err(())
+        } else {
+            FromStr::from_str(par.value())
+        }
+    }
+}
+
+impl FromStr for ValueType {
+    type Err = ();
+
+    fn from_str(val: &str) -> Result<Self, Self::Err> {
+        match val {
+            "BINARY" => Ok(Self::Binary),
+            "BOOLEAN" => Ok(Self::Boolean),
+            "CAL-ADDRESS" => Ok(Self::CalAddress),
+            "DATE" => Ok(Self::Date),
+            "DATE-TIME" => Ok(Self::DateTime),
+            "DURATION" => Ok(Self::Duration),
+            "FLOAT" => Ok(Self::Float),
+            "INTEGER" => Ok(Self::Integer),
+            "PERIOD" => Ok(Self::Period),
+            "RECUR" => Ok(Self::Recur),
+            "TEXT" => Ok(Self::Text),
+            "TIME" => Ok(Self::Time),
+            "URI" => Ok(Self::Uri),
+            "UTC-OFFSET" => Ok(Self::UtcOffset),
+            _ => Err(()),
+        }
+    }
+}


### PR DESCRIPTION
We now look determine the value-type of a property (either by name or parameter) and escape/unescape accordingly.
This fixes #104 

At the moment this only distinguishes between `TEXT` and non-`TEXT`, but technically the value type should also be considered when parsing dates vs durations etc. 
