### PR TITLE
fix: wrapping behaviour does no take added space into account

### DIFF
--- a/src/properties.rs
+++ b/src/properties.rs
@@ -380,14 +380,15 @@ impl From<chrono::Duration> for Property {
 // Fold a content line as described in RFC 5545, Section 3.1
 #[allow(clippy::indexing_slicing)]
 pub(crate) fn fold_line(line: &str) -> String {
-    let limit = 75;
+    const LIMIT: usize = 75;
     let len = line.len();
-    let mut ret = String::with_capacity(len + (len / limit * 3));
+    let mut ret = String::with_capacity(len + (len / LIMIT * 3));
     let mut bytes_remaining = len;
 
     let mut pos = 0;
-    let mut next_pos = limit;
-    while bytes_remaining > limit {
+    let mut next_pos = LIMIT;
+
+    while bytes_remaining > LIMIT {
         let pos_is_whitespace = |line: &str, next_pos| {
             line.chars()
                 .nth(next_pos)
@@ -409,7 +410,7 @@ pub(crate) fn fold_line(line: &str) -> String {
 
         bytes_remaining -= next_pos - pos;
         pos = next_pos;
-        next_pos += limit;
+        next_pos += LIMIT - 1;
     }
 
     ret.push_str(&line[len - bytes_remaining..]);

--- a/tests/reserialize.rs
+++ b/tests/reserialize.rs
@@ -33,8 +33,8 @@ ACTION:EMAIL\r
 ATTENDEE:\"mailto:john_doe@example.com\"\r
 SUMMARY:*** REMINDER: SEND AGENDA FOR WEEKLY STAFF MEETING ***\r
 DESCRIPTION:A draft agenda needs to be sent out to the attendees to the wee\r
- kly managers meeting (MGR-LIST). Attached is a pointer the document templat\r
- e for the agenda file.\r
+ kly managers meeting (MGR-LIST). Attached is a pointer the document templa\r
+ te for the agenda file.\r
 ATTACH;FMTTYPE=application/msword:http://example.com/templates/agenda.doc\r
 END:VALARM\r
 END:VCALENDAR\r


### PR DESCRIPTION
Thanks for this crates, it is really ergonomic to use, but I found a little uncommon bug:

In the section 3.1 of RFC 5545, the line size limit is stated to be no more than 75 bytes excluding the linebreak. This does not exclude the space character from the 75 bytes limit, so it needs to be taken into account in the folding algorithm. This PR fixes this bug and the corresponding test that assert the 76 bytes line.