### PR TITLE
refactor: standardizes Property::new and Property::new_pre_alloc methods with generics

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!--
+First and foremost, thank you for taking the time to contribute to this project! Your efforts are greatly appreciated.
+
+## Semantic Commit Messages
+Please ensure your commit messages follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/),
+as these are being used to automatically generate the changelog and determine the version bump for releases.
+
+Most importantly: [Mark breaking changes accordingly](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer)!
+
+### Example
+```
+feat: add new user authentication module
+
+fix: resolve issue with user not being able to login
+
+feat!: remove deprecated user module
+```
+->>
+
+
+Again, thank you for your contribution!
+If you have any questions or need assistance, don't hesitate to ask. We're here to help!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - beta 
+          - beta
           - stable minus 8 releases
     steps:
       - uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v2
+        uses: obi1kenobi/cargo-semver-checks-action@v2.6
 
   fmtclippy:
     runs-on: ubuntu-latest
@@ -67,4 +67,4 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: cargo-fmt
-        run: cargo fmt --all --check 
+        run: cargo fmt --all --check

--- a/src/components.rs
+++ b/src/components.rs
@@ -164,7 +164,7 @@ pub trait Component {
     ///
     /// This must be a UTC date-time value.
     fn timestamp(&mut self, dt: DateTime<Utc>) -> &mut Self {
-        self.add_property("DTSTAMP", &format_utc_date_time(dt))
+        self.add_property("DTSTAMP", format_utc_date_time(dt))
     }
 
     /// Gets the [`DTSTAMP`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.7.2) property.
@@ -187,7 +187,7 @@ pub trait Component {
     /// Ranges from 0 to 10, larger values will be truncated
     fn priority(&mut self, priority: u32) -> &mut Self {
         let priority = std::cmp::min(priority, 10);
-        self.add_property("PRIORITY", &priority.to_string())
+        self.add_property("PRIORITY", priority.to_string())
     }
 
     // /// Add the [`ATTACH`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.1.1) property

--- a/src/components.rs
+++ b/src/components.rs
@@ -145,13 +145,14 @@ pub trait Component {
     fn append_multi_property(&mut self, property: impl Into<Property>) -> &mut Self;
 
     /// Construct and append a [`Property`]
-    fn add_property(&mut self, key: &str, val: &str) -> &mut Self {
+    fn add_property(&mut self, key: impl Into<String>, val: impl Into<String>) -> &mut Self {
         self.append_property(Property::new(key, val))
     }
 
+    #[deprecated]
     /// Construct and append a [`Property`]
     fn add_property_pre_alloc(&mut self, key: String, val: String) -> &mut Self {
-        self.append_property(Property::new_pre_alloc(key, val))
+        self.append_property(Property::new(key, val))
     }
 
     /// Construct and append a [`Property`]
@@ -254,7 +255,7 @@ pub trait Component {
 
     /// Set the sequence
     fn sequence(&mut self, sequence: u32) -> &mut Self {
-        self.add_property_pre_alloc("SEQUENCE".into(), sequence.to_string())
+        self.add_property("SEQUENCE", sequence.to_string())
     }
 
     /// Gets the SEQUENCE

--- a/src/components/alarm.rs
+++ b/src/components/alarm.rs
@@ -351,7 +351,7 @@ pub mod properties {
 
     impl From<Repeat> for Property {
         fn from(r: Repeat) -> Self {
-            Property::new_pre_alloc("REPEAT".into(), r.0.to_string())
+            Property::new("REPEAT", r.0.to_string())
         }
     }
 
@@ -544,14 +544,12 @@ pub mod properties {
         fn from(trigger: Trigger) -> Self {
             match trigger {
                 Trigger::Duration(duration, Some(related)) => {
-                    Property::new_pre_alloc("TRIGGER".into(), duration.to_string())
+                    Property::new("TRIGGER", duration.to_string())
                         .append_parameter(related)
                         .done()
                 }
 
-                Trigger::Duration(duration, None) => {
-                    Property::new_pre_alloc("TRIGGER".into(), duration.to_string())
-                }
+                Trigger::Duration(duration, None) => Property::new("TRIGGER", duration.to_string()),
 
                 Trigger::DateTime(dt) => dt
                     .to_property("TRIGGER")

--- a/src/components/date_time.rs
+++ b/src/components/date_time.rs
@@ -28,7 +28,7 @@ pub(crate) fn parse_duration(s: &str) -> Option<Duration> {
 }
 
 pub(crate) fn naive_date_to_property(date: NaiveDate, key: &str) -> Property {
-    Property::new(key, &date.format(NAIVE_DATE_FORMAT).to_string())
+    Property::new(key, date.format(NAIVE_DATE_FORMAT).to_string())
         .append_parameter(ValueType::Date)
         .done()
 }
@@ -97,11 +97,11 @@ impl CalendarDateTime {
     pub(crate) fn to_property(&self, key: &str) -> Property {
         match self {
             CalendarDateTime::Floating(naive_dt) => {
-                Property::new(key, &naive_dt.format(NAIVE_DATE_TIME_FORMAT).to_string())
+                Property::new(key, naive_dt.format(NAIVE_DATE_TIME_FORMAT).to_string())
             }
-            CalendarDateTime::Utc(utc_dt) => Property::new(key, &format_utc_date_time(*utc_dt)),
+            CalendarDateTime::Utc(utc_dt) => Property::new(key, format_utc_date_time(*utc_dt)),
             CalendarDateTime::WithTimezone { date_time, tzid } => {
-                Property::new(key, &date_time.format(NAIVE_DATE_TIME_FORMAT).to_string())
+                Property::new(key, date_time.format(NAIVE_DATE_TIME_FORMAT).to_string())
                     .add_parameter("TZID", tzid)
                     .done()
             }

--- a/src/components/todo.rs
+++ b/src/components/todo.rs
@@ -26,7 +26,7 @@ impl Todo {
     ///
     /// Ranges between 0 - 100
     pub fn percent_complete(&mut self, percent: u8) -> &mut Self {
-        self.add_property("PERCENT-COMPLETE", &percent.to_string())
+        self.add_property("PERCENT-COMPLETE", percent.to_string())
     }
 
     /// Gets the [`PERCENT-COMPLETE`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.1.8) property.
@@ -54,7 +54,7 @@ impl Todo {
     /// Per [RFC 5545, Section 3.8.2.1](https://tools.ietf.org/html/rfc5545#section-3.8.2.1), this
     /// must be a date-time in UTC format.
     pub fn completed(&mut self, dt: DateTime<Utc>) -> &mut Self {
-        self.add_property("COMPLETED", &format_utc_date_time(dt))
+        self.add_property("COMPLETED", format_utc_date_time(dt))
     }
 
     /// Gets the [`COMPLETED`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.1) property

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -53,14 +53,15 @@ impl From<(&str, &str)> for Property {
 
 impl Property {
     /// Guess what this does :D
-    pub fn new(key: &str, val: &str) -> Self {
+    pub fn new(key: impl Into<String>, val: impl Into<String>) -> Self {
         Property {
-            key: key.to_owned(),
-            val: val.to_owned(),
+            key: key.into(),
+            val: val.into(),
             params: HashMap::new(),
         }
     }
 
+    #[deprecated]
     /// if you already have `String`s I'll gladly take
     pub fn new_pre_alloc(key: String, val: String) -> Self {
         Property {
@@ -333,22 +334,22 @@ impl From<ValueType> for Parameter {
 
 impl From<TodoStatus> for Property {
     fn from(val: TodoStatus) -> Self {
-        Property::new_pre_alloc(
-            String::from("STATUS"),
-            String::from(match val {
+        Property::new(
+            "STATUS",
+            match val {
                 TodoStatus::NeedsAction => "NEEDS-ACTION",
                 TodoStatus::Completed => "COMPLETED",
                 TodoStatus::InProcess => "IN-PROCESS",
                 TodoStatus::Cancelled => "CANCELLED",
                 //TodoStatus::Custom(s)   => "CU",
-            }),
+            },
         )
     }
 }
 
 impl From<chrono::Duration> for Property {
     fn from(duration: chrono::Duration) -> Self {
-        Property::new_pre_alloc(String::from("DURATION"), duration.to_string())
+        Property::new("DURATION", duration.to_string())
     }
 }
 //pub enum AttendeeRole {

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -381,14 +381,15 @@ impl From<chrono::Duration> for Property {
 // Fold a content line as described in RFC 5545, Section 3.1
 #[allow(clippy::indexing_slicing)]
 pub(crate) fn fold_line(line: &str) -> String {
-    let limit = 75;
+    const LIMIT: usize = 75;
     let len = line.len();
-    let mut ret = String::with_capacity(len + (len / limit * 3));
+    let mut ret = String::with_capacity(len + (len / LIMIT * 3));
     let mut bytes_remaining = len;
 
     let mut pos = 0;
-    let mut next_pos = limit;
-    while bytes_remaining > limit {
+    let mut next_pos = LIMIT;
+
+    while bytes_remaining > LIMIT {
         let pos_is_whitespace = |line: &str, next_pos| {
             line.chars()
                 .nth(next_pos)
@@ -410,7 +411,7 @@ pub(crate) fn fold_line(line: &str) -> String {
 
         bytes_remaining -= next_pos - pos;
         pos = next_pos;
-        next_pos += limit;
+        next_pos += LIMIT - 1;
     }
 
     ret.push_str(&line[len - bytes_remaining..]);

--- a/tests/reserialize.rs
+++ b/tests/reserialize.rs
@@ -33,8 +33,8 @@ ACTION:EMAIL\r
 ATTENDEE:\"mailto:john_doe@example.com\"\r
 SUMMARY:*** REMINDER: SEND AGENDA FOR WEEKLY STAFF MEETING ***\r
 DESCRIPTION:A draft agenda needs to be sent out to the attendees to the wee\r
- kly managers meeting (MGR-LIST). Attached is a pointer the document templat\r
- e for the agenda file.\r
+ kly managers meeting (MGR-LIST). Attached is a pointer the document templa\r
+ te for the agenda file.\r
 ATTACH;FMTTYPE=application/msword:http://example.com/templates/agenda.doc\r
 END:VALARM\r
 END:VCALENDAR\r


### PR DESCRIPTION
Another little PR, but it is only to make the user interface a bit nicer to work with.

It allows to use the same function for owned String and slices. By using `impl Into<String>`, it convert string slices to String when it receives a string slices, but when a String is passed, it will just move it. The implementation of Into<T> for the same type is a function that just return the same type, so it's a zero cost operation. [https://doc.rust-lang.org/src/core/convert/mod.rs.html#763-771](https://doc.rust-lang.org/src/core/convert/mod.rs.html#763-771)

I marked the old method deprecated, so at the next major release with breaking changes, they could be removed.