### PR TITLE
fix: remove colon escape in text property

### DIFF
--- a/src/properties.rs
+++ b/src/properties.rs
@@ -439,6 +439,14 @@ mod tests {
         assert_eq!(expected, fold_line(line));
     }
 
+    #[test]
+    fn escape_special_characters_in_text() {
+        let line = "\n\\;,:";
+
+        let expected = r"\N\\\;\,:";
+        assert_eq!(expected, Property::escape_text(line));
+    }
+
     #[cfg(feature = "parser")]
     #[test]
     fn preserve_spaces() {

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -153,7 +153,6 @@ impl Property {
             .replace('\\', r#"\\"#)
             .replace(',', r#"\,"#)
             .replace(';', r#"\;"#)
-            .replace(':', r#"\:"#)
             .replace('\n', r#"\N"#)
     }
 


### PR DESCRIPTION
As outlined in #111, COLONs should not be escaped with a BACKSLASH in a TEXT property (capitalization to match the spec).

This removes the line I found that was doing it, a quick test run generated a valid ical file based on my usecase (as validated via https://icalendar.org/validator.html)

All tests still pass. I'm however unfamiliar with the code base and my usecase is limited in complexity, so please double check me
