### PR TITLE
feat: make DatePerhapsTime::to_property() publicly accessible

### DIFF
--- a/src/components/date_time.rs
+++ b/src/components/date_time.rs
@@ -260,7 +260,7 @@ impl DatePerhapsTime {
         }
     }
 
-    pub(crate) fn to_property(&self, key: &str) -> Property {
+    pub fn to_property(&self, key: &str) -> Property {
         match self {
             Self::DateTime(date_time) => date_time.to_property(key),
             Self::Date(date) => naive_date_to_property(*date, key),


### PR DESCRIPTION
This allows to create properties that require a DATE-TIME as a value and don't have dedicated functions like `DTSTART` and `DTEND`.

<!--
First and foremost, thank you for taking the time to contribute to this project! Your efforts are greatly appreciated.

## Semantic Commit Messages
Please ensure your commit messages follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/),
as these are being used to automatically generate the changelog and determine the version bump for releases.

Most importantly: [Mark breaking changes accordingly](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer)!

### Example
```
feat: add new user authentication module

fix: resolve issue with user not being able to login

feat!: remove deprecated user module
```
->>


Again, thank you for your contribution!
If you have any questions or need assistance, don't hesitate to ask. We're here to help!
