### PR TITLE
feat: expose `DatePerhapsTime` property roundtrip methods as public API

### DIFF
--- a/src/components/date_time.rs
+++ b/src/components/date_time.rs
@@ -248,7 +248,8 @@ pub enum DatePerhapsTime {
 }
 
 impl DatePerhapsTime {
-    pub(crate) fn from_property(property: &Property) -> Option<Self> {
+    /// Attempts to convert the given property into a `DatePerhapsTime`.
+    pub fn from_property(property: &Property) -> Option<Self> {
         if property.value_type() == Some(ValueType::Date) {
             Some(
                 NaiveDate::parse_from_str(property.value(), NAIVE_DATE_FORMAT)
@@ -260,12 +261,14 @@ impl DatePerhapsTime {
         }
     }
 
-    pub(crate) fn to_property(&self, key: &str) -> Property {
+    /// Converts this `DatePerhapsTime` into a `Property`.
+    pub fn to_property(&self, key: &str) -> Property {
         match self {
             Self::DateTime(date_time) => date_time.to_property(key),
             Self::Date(date) => naive_date_to_property(*date, key),
         }
     }
+
     /// Discards time, assumes UTC, and returns an owned instance of a pure date
     pub fn date_naive(&self) -> NaiveDate {
         use crate::DatePerhapsTime::*;


### PR DESCRIPTION
This PR exposes the aforementioned methods as part of the public API. These methods are valuable for downstream consumers who need to interpret properties that may hold date or datetime values, as defined by the iCalendar standard and beyond. There doesn't appear to be a compelling reason to keep these methods private, as their usefulness extends beyond internal implementation details and they cannot be misused to violate invariants.

For example, I found these methods particularly helpful for safely extracting `RECURRENCE-ID`, `RDATE`s, and `EXDATE` values to pass along to the [`rrule`](https://crates.io/crates/rrule) crate to expand recurring `VEVENT`s.